### PR TITLE
Fix collector and export bugs (#60, #61, #62, #63)

### DIFF
--- a/src/collectors/anthropic.rs
+++ b/src/collectors/anthropic.rs
@@ -21,23 +21,46 @@ impl AnthropicCollector {
     }
 }
 
+/// Anthropic Messages Usage Report API response.
+/// GET /v1/organizations/usage_report/messages — admin API key required.
+/// See https://docs.anthropic.com/en/api/usage-cost-api
 #[derive(Debug, Deserialize)]
 struct UsageResponse {
     data: Vec<UsageBucket>,
+    #[serde(default)]
+    has_more: bool,
+    #[serde(default)]
+    next_page: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
 struct UsageBucket {
     #[serde(default)]
-    model: Option<String>,
-    input_tokens: i64,
-    output_tokens: i64,
+    starting_at: Option<String>,
     #[serde(default)]
-    cache_creation_input_tokens: i64,
+    results: Vec<BucketResult>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BucketResult {
+    #[serde(default)]
+    model: Option<String>,
+    #[serde(default)]
+    uncached_input_tokens: i64,
+    #[serde(default)]
+    output_tokens: i64,
     #[serde(default)]
     cache_read_input_tokens: i64,
     #[serde(default)]
-    date: Option<String>,
+    cache_creation: Option<CacheCreation>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CacheCreation {
+    #[serde(default)]
+    ephemeral_5m_input_tokens: i64,
+    #[serde(default)]
+    ephemeral_1h_input_tokens: i64,
 }
 
 #[async_trait]
@@ -47,67 +70,163 @@ impl Collector for AnthropicCollector {
     }
 
     async fn collect(&self) -> Result<Vec<UsageRecord>> {
-        // Anthropic Admin API: GET /v1/organizations/usage
-        // Requires admin API key with usage:read scope
         let now = Utc::now();
         let start = (now - chrono::Duration::days(30))
-            .format("%Y-%m-%d")
+            .format("%Y-%m-%dT%H:%M:%SZ")
             .to_string();
-        let end = now.format("%Y-%m-%d").to_string();
+        let end = now.format("%Y-%m-%dT%H:%M:%SZ").to_string();
 
-        let resp = self
-            .client
-            .get("https://api.anthropic.com/v1/organizations/usage")
-            .header("x-api-key", &self.api_key)
-            .header("anthropic-version", "2023-06-01")
-            .query(&[
-                ("start_date", start.as_str()),
-                ("end_date", end.as_str()),
-                ("group_by", "model"),
-            ])
-            .send()
-            .await?;
+        let collected_at = now.to_rfc3339();
+        let mut records: Vec<UsageRecord> = Vec::new();
+        let mut page_token: Option<String> = None;
 
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let body = resp.text().await.unwrap_or_default();
-            anyhow::bail!("Anthropic API error {}: {}", status, body);
+        loop {
+            let mut query: Vec<(&str, String)> = vec![
+                ("starting_at", start.clone()),
+                ("ending_at", end.clone()),
+                ("bucket_width", "1d".to_string()),
+                ("group_by[]", "model".to_string()),
+                ("limit", "31".to_string()),
+            ];
+            if let Some(p) = &page_token {
+                query.push(("page", p.clone()));
+            }
+
+            let resp = self
+                .client
+                .get("https://api.anthropic.com/v1/organizations/usage_report/messages")
+                .header("x-api-key", &self.api_key)
+                .header("anthropic-version", "2023-06-01")
+                .query(&query)
+                .send()
+                .await?;
+
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let body = resp.text().await.unwrap_or_default();
+                anyhow::bail!("Anthropic usage API error {}: {}", status, body);
+            }
+
+            let usage: UsageResponse = resp.json().await?;
+
+            for bucket in usage.data {
+                let recorded_at = bucket
+                    .starting_at
+                    .as_deref()
+                    .and_then(|s| s.split('T').next())
+                    .map(|d| d.to_string())
+                    .unwrap_or_else(|| now.format("%Y-%m-%d").to_string());
+
+                for result in bucket.results {
+                    let cache_write = result
+                        .cache_creation
+                        .as_ref()
+                        .map(|c| c.ephemeral_5m_input_tokens + c.ephemeral_1h_input_tokens)
+                        .unwrap_or(0);
+
+                    if result.uncached_input_tokens == 0
+                        && result.output_tokens == 0
+                        && result.cache_read_input_tokens == 0
+                        && cache_write == 0
+                    {
+                        continue;
+                    }
+
+                    let model = result.model.unwrap_or_else(|| "unknown".to_string());
+                    let cost = costs::calculate_cost(
+                        &model,
+                        "anthropic",
+                        result.uncached_input_tokens,
+                        result.output_tokens,
+                        result.cache_read_input_tokens,
+                        cache_write,
+                    );
+                    records.push(UsageRecord {
+                        id: None,
+                        provider: "anthropic".to_string(),
+                        model,
+                        input_tokens: result.uncached_input_tokens,
+                        output_tokens: result.output_tokens,
+                        cache_read_tokens: result.cache_read_input_tokens,
+                        cache_write_tokens: cache_write,
+                        cost_usd: cost,
+                        session_id: None,
+                        recorded_at: recorded_at.clone(),
+                        collected_at: collected_at.clone(),
+                        metadata: None,
+                    });
+                }
+            }
+
+            if !usage.has_more {
+                break;
+            }
+            match usage.next_page {
+                Some(p) if !p.is_empty() => page_token = Some(p),
+                _ => break,
+            }
         }
 
-        let usage: UsageResponse = resp.json().await?;
-        let collected_at = Utc::now().to_rfc3339();
-
-        let records = usage
-            .data
-            .into_iter()
-            .filter(|b| b.input_tokens > 0 || b.output_tokens > 0)
-            .map(|b| {
-                let model = b.model.unwrap_or_else(|| "unknown".to_string());
-                let cost = costs::calculate_cost(
-                    &model,
-                    "anthropic",
-                    b.input_tokens,
-                    b.output_tokens,
-                    b.cache_read_input_tokens,
-                    b.cache_creation_input_tokens,
-                );
-                UsageRecord {
-                    id: None,
-                    provider: "anthropic".to_string(),
-                    model,
-                    input_tokens: b.input_tokens,
-                    output_tokens: b.output_tokens,
-                    cache_read_tokens: b.cache_read_input_tokens,
-                    cache_write_tokens: b.cache_creation_input_tokens,
-                    cost_usd: cost,
-                    session_id: None,
-                    recorded_at: b.date.unwrap_or_else(|| now.format("%Y-%m-%d").to_string()),
-                    collected_at: collected_at.clone(),
-                    metadata: None,
-                }
-            })
-            .collect();
-
         Ok(records)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_usage_report_response() {
+        let sample = r#"{
+            "data": [
+                {
+                    "starting_at": "2026-04-15T00:00:00Z",
+                    "ending_at": "2026-04-16T00:00:00Z",
+                    "results": [
+                        {
+                            "model": "claude-sonnet-4-6",
+                            "uncached_input_tokens": 10000,
+                            "output_tokens": 2500,
+                            "cache_read_input_tokens": 3000,
+                            "cache_creation": {
+                                "ephemeral_5m_input_tokens": 500,
+                                "ephemeral_1h_input_tokens": 200
+                            },
+                            "server_tool_use": { "web_search_requests": 0 }
+                        }
+                    ]
+                }
+            ],
+            "has_more": false,
+            "next_page": null
+        }"#;
+
+        let parsed: UsageResponse = serde_json::from_str(sample).unwrap();
+        assert_eq!(parsed.data.len(), 1);
+        let r = &parsed.data[0].results[0];
+        assert_eq!(r.uncached_input_tokens, 10000);
+        assert_eq!(r.output_tokens, 2500);
+        assert_eq!(r.cache_read_input_tokens, 3000);
+        let cc = r.cache_creation.as_ref().unwrap();
+        assert_eq!(cc.ephemeral_5m_input_tokens, 500);
+        assert_eq!(cc.ephemeral_1h_input_tokens, 200);
+        assert_eq!(r.model.as_deref(), Some("claude-sonnet-4-6"));
+    }
+
+    #[test]
+    fn extracts_date_from_starting_at() {
+        let sample = r#"{
+            "data": [
+                {"starting_at": "2026-04-15T00:00:00Z", "ending_at": "2026-04-16T00:00:00Z", "results": []}
+            ],
+            "has_more": false
+        }"#;
+        let parsed: UsageResponse = serde_json::from_str(sample).unwrap();
+        let date = parsed.data[0]
+            .starting_at
+            .as_deref()
+            .and_then(|s| s.split('T').next())
+            .unwrap();
+        assert_eq!(date, "2026-04-15");
     }
 }

--- a/src/collectors/codex.rs
+++ b/src/collectors/codex.rs
@@ -109,10 +109,13 @@ impl Collector for CodexCollector {
             // Codex uses GPT-5 or similar via OpenAI
             let model = format!("codex-{}", model_provider);
 
-            // Second pass: collect token_count entries
-            // Use last_token_usage which gives per-turn deltas
-            let mut prev_input: i64 = 0;
-            let mut prev_output: i64 = 0;
+            // Second pass: collect token_count entries.
+            // Codex occasionally re-emits the exact same event line (e.g. on session
+            // end), so we dedupe on the full raw line. Distinct turns that happen to
+            // share identical token counts will still have different timestamps and
+            // therefore different serialized lines, so they survive.
+            let mut seen_lines: std::collections::HashSet<String> =
+                std::collections::HashSet::new();
 
             for line in content.lines() {
                 if !line.contains("token_count") {
@@ -135,20 +138,19 @@ impl Collector for CodexCollector {
                                 serde_json::from_value::<TokenInfo>(info.clone())
                             {
                                 if let Some(usage) = token_info.last_token_usage {
+                                    if !seen_lines.insert(line.to_string()) {
+                                        continue;
+                                    }
+
                                     // last_token_usage gives per-turn values
                                     let input = usage.input_tokens;
                                     let output =
                                         usage.output_tokens + usage.reasoning_output_tokens;
 
-                                    // Skip if same as previous (duplicate event)
-                                    if input == prev_input && output == prev_output {
+                                    if input == 0 && output == 0 && usage.cached_input_tokens == 0
+                                    {
                                         continue;
                                     }
-                                    if input == 0 && output == 0 {
-                                        continue;
-                                    }
-                                    prev_input = input;
-                                    prev_output = output;
 
                                     let cost = costs::calculate_cost(
                                         &model,

--- a/src/collectors/codex.rs
+++ b/src/collectors/codex.rs
@@ -147,8 +147,7 @@ impl Collector for CodexCollector {
                                     let output =
                                         usage.output_tokens + usage.reasoning_output_tokens;
 
-                                    if input == 0 && output == 0 && usage.cached_input_tokens == 0
-                                    {
+                                    if input == 0 && output == 0 && usage.cached_input_tokens == 0 {
                                         continue;
                                     }
 

--- a/src/collectors/openai.rs
+++ b/src/collectors/openai.rs
@@ -21,21 +21,36 @@ impl OpenAICollector {
     }
 }
 
+/// OpenAI organization usage (completions) API response.
+/// GET /v1/organization/usage/completions — admin API key required.
+/// See https://platform.openai.com/docs/api-reference/usage/completions
 #[derive(Debug, Deserialize)]
 struct UsageResponse {
-    data: Vec<UsageBucket>,
+    data: Vec<Bucket>,
+    #[serde(default)]
+    has_more: bool,
+    #[serde(default)]
+    next_page: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
-struct UsageBucket {
+struct Bucket {
     #[serde(default)]
-    aggregation_timestamp: i64,
+    start_time: i64,
     #[serde(default)]
-    n_context_tokens_total: i64,
+    results: Vec<BucketResult>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BucketResult {
     #[serde(default)]
-    n_generated_tokens_total: i64,
+    input_tokens: i64,
     #[serde(default)]
-    snapshot_id: Option<String>,
+    output_tokens: i64,
+    #[serde(default)]
+    input_cached_tokens: i64,
+    #[serde(default)]
+    model: Option<String>,
 }
 
 #[async_trait]
@@ -45,63 +60,144 @@ impl Collector for OpenAICollector {
     }
 
     async fn collect(&self) -> Result<Vec<UsageRecord>> {
-        // OpenAI Usage API: GET /v1/organization/usage
-        // Groups by model (snapshot_id)
         let now = Utc::now();
         let start_time = (now - chrono::Duration::days(30)).timestamp();
 
-        let resp = self
-            .client
-            .get("https://api.openai.com/v1/organization/usage")
-            .bearer_auth(&self.api_key)
-            .query(&[("start_time", &start_time.to_string())])
-            .send()
-            .await?;
+        let collected_at = now.to_rfc3339();
+        let mut records: Vec<UsageRecord> = Vec::new();
+        let mut page_token: Option<String> = None;
 
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let body = resp.text().await.unwrap_or_default();
-            anyhow::bail!("OpenAI API error {}: {}", status, body);
-        }
+        loop {
+            let mut query: Vec<(&str, String)> = vec![
+                ("start_time", start_time.to_string()),
+                ("bucket_width", "1d".to_string()),
+                ("group_by[]", "model".to_string()),
+                ("limit", "31".to_string()),
+            ];
+            if let Some(p) = &page_token {
+                query.push(("page", p.clone()));
+            }
 
-        let usage: UsageResponse = resp.json().await?;
-        let collected_at = Utc::now().to_rfc3339();
+            let resp = self
+                .client
+                .get("https://api.openai.com/v1/organization/usage/completions")
+                .bearer_auth(&self.api_key)
+                .query(&query)
+                .send()
+                .await?;
 
-        let records = usage
-            .data
-            .into_iter()
-            .filter(|b| b.n_context_tokens_total > 0 || b.n_generated_tokens_total > 0)
-            .map(|b| {
-                let model = b.snapshot_id.unwrap_or_else(|| "unknown".to_string());
-                let cost = costs::calculate_cost(
-                    &model,
-                    "openai",
-                    b.n_context_tokens_total,
-                    b.n_generated_tokens_total,
-                    0,
-                    0,
-                );
-                let recorded_at = chrono::DateTime::from_timestamp(b.aggregation_timestamp, 0)
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let body = resp.text().await.unwrap_or_default();
+                anyhow::bail!("OpenAI usage API error {}: {}", status, body);
+            }
+
+            let usage: UsageResponse = resp.json().await?;
+
+            for bucket in usage.data {
+                let recorded_at = chrono::DateTime::from_timestamp(bucket.start_time, 0)
                     .map(|dt| dt.format("%Y-%m-%d").to_string())
                     .unwrap_or_else(|| now.format("%Y-%m-%d").to_string());
 
-                UsageRecord {
-                    id: None,
-                    provider: "openai".to_string(),
-                    model,
-                    input_tokens: b.n_context_tokens_total,
-                    output_tokens: b.n_generated_tokens_total,
-                    cache_read_tokens: 0,
-                    cache_write_tokens: 0,
-                    cost_usd: cost,
-                    session_id: None,
-                    recorded_at,
-                    collected_at: collected_at.clone(),
-                    metadata: None,
+                for result in bucket.results {
+                    if result.input_tokens == 0
+                        && result.output_tokens == 0
+                        && result.input_cached_tokens == 0
+                    {
+                        continue;
+                    }
+                    let model = result.model.unwrap_or_else(|| "unknown".to_string());
+                    let cost = costs::calculate_cost(
+                        &model,
+                        "openai",
+                        result.input_tokens,
+                        result.output_tokens,
+                        result.input_cached_tokens,
+                        0,
+                    );
+                    records.push(UsageRecord {
+                        id: None,
+                        provider: "openai".to_string(),
+                        model,
+                        input_tokens: result.input_tokens,
+                        output_tokens: result.output_tokens,
+                        cache_read_tokens: result.input_cached_tokens,
+                        cache_write_tokens: 0,
+                        cost_usd: cost,
+                        session_id: None,
+                        recorded_at: recorded_at.clone(),
+                        collected_at: collected_at.clone(),
+                        metadata: None,
+                    });
                 }
-            })
-            .collect();
+            }
+
+            if !usage.has_more {
+                break;
+            }
+            match usage.next_page {
+                Some(p) if !p.is_empty() => page_token = Some(p),
+                _ => break,
+            }
+        }
 
         Ok(records)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_bucket_response() {
+        let sample = r#"{
+            "data": [
+                {
+                    "object": "bucket",
+                    "start_time": 1709251200,
+                    "end_time": 1709337600,
+                    "results": [
+                        {
+                            "object": "organization.usage.completions.result",
+                            "input_tokens": 1200,
+                            "output_tokens": 400,
+                            "input_cached_tokens": 100,
+                            "num_model_requests": 5,
+                            "model": "gpt-4o-mini"
+                        },
+                        {
+                            "object": "organization.usage.completions.result",
+                            "input_tokens": 0,
+                            "output_tokens": 0,
+                            "input_cached_tokens": 0,
+                            "model": "gpt-4o"
+                        }
+                    ]
+                }
+            ],
+            "has_more": false,
+            "next_page": null
+        }"#;
+
+        let parsed: UsageResponse = serde_json::from_str(sample).unwrap();
+        assert_eq!(parsed.data.len(), 1);
+        assert_eq!(parsed.data[0].results.len(), 2);
+        assert_eq!(parsed.data[0].results[0].input_tokens, 1200);
+        assert_eq!(parsed.data[0].results[0].input_cached_tokens, 100);
+        assert_eq!(parsed.data[0].results[0].model.as_deref(), Some("gpt-4o-mini"));
+        assert!(!parsed.has_more);
+    }
+
+    #[test]
+    fn parses_paginated_response() {
+        let sample = r#"{
+            "data": [],
+            "has_more": true,
+            "next_page": "page_abc123"
+        }"#;
+        let parsed: UsageResponse = serde_json::from_str(sample).unwrap();
+        assert!(parsed.has_more);
+        assert_eq!(parsed.next_page.as_deref(), Some("page_abc123"));
     }
 }

--- a/src/collectors/openai.rs
+++ b/src/collectors/openai.rs
@@ -185,7 +185,10 @@ mod tests {
         assert_eq!(parsed.data[0].results.len(), 2);
         assert_eq!(parsed.data[0].results[0].input_tokens, 1200);
         assert_eq!(parsed.data[0].results[0].input_cached_tokens, 100);
-        assert_eq!(parsed.data[0].results[0].model.as_deref(), Some("gpt-4o-mini"));
+        assert_eq!(
+            parsed.data[0].results[0].model.as_deref(),
+            Some("gpt-4o-mini")
+        );
         assert!(!parsed.has_more);
     }
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -64,7 +64,7 @@ impl Database {
         provider: Option<&str>,
         since: Option<&str>,
         until: Option<&str>,
-        limit: usize,
+        limit: Option<usize>,
     ) -> Result<Vec<crate::models::UsageRecord>> {
         queries::query_detail(&self.conn, model, provider, since, until, limit)
     }

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -89,7 +89,7 @@ pub fn query_detail(
     provider: Option<&str>,
     since: Option<&str>,
     until: Option<&str>,
-    limit: usize,
+    limit: Option<usize>,
 ) -> Result<Vec<UsageRecord>> {
     let mut sql = String::from("SELECT * FROM usage_records WHERE 1=1");
     let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = vec![];
@@ -119,7 +119,10 @@ pub fn query_detail(
         param_values.push(Box::new(until_val));
     }
 
-    sql.push_str(&format!(" ORDER BY recorded_at DESC LIMIT {}", limit));
+    sql.push_str(" ORDER BY recorded_at DESC");
+    if let Some(n) = limit {
+        sql.push_str(&format!(" LIMIT {}", n));
+    }
 
     let params_refs: Vec<&dyn rusqlite::types::ToSql> =
         param_values.iter().map(|p| p.as_ref()).collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -330,7 +330,7 @@ fn cmd_detail(
     until: Option<&str>,
     limit: usize,
 ) -> Result<()> {
-    let rows = db.query_detail(model, provider, since, until, limit)?;
+    let rows = db.query_detail(model, provider, since, until, Some(limit))?;
     display::print_detail(&rows);
     Ok(())
 }
@@ -367,7 +367,7 @@ async fn cmd_update_pricing() -> Result<()> {
 fn cmd_export(db: &db::Database, format: &str, output: Option<&str>, days: u32) -> Result<()> {
     let since = chrono::Utc::now() - chrono::Duration::days(days as i64);
     let since_str = since.format("%Y-%m-%d").to_string();
-    let rows = db.query_detail(None, None, Some(&since_str), None, 100_000)?;
+    let rows = db.query_detail(None, None, Some(&since_str), None, None)?;
     let content = match format {
         "json" => display::to_json(&rows)?,
         _ => display::to_csv(&rows)?,


### PR DESCRIPTION
## Summary

Four bug fixes across API collectors and the export command:

- **#60** OpenAI collector rewritten against the current `/v1/organization/usage/completions` contract: bucket→results[] schema, `has_more`/`next_page` pagination, grouping by model, correct `input_tokens`/`output_tokens`/`input_cached_tokens` field names.
- **#61** Codex collector no longer drops distinct turns whose token deltas happen to match. Dedup is now keyed on raw line identity (re-emitted identical events still collapse, but two different turns with the same counts both land). `cached_input_tokens` is respected in the zero-skip check.
- **#62** Export command removes the silent 100,000-row truncation. `db.query_detail` takes `Option<usize>`; export passes `None` for unlimited. `detail` still honors its `--limit` CLI flag.
- **#63** Anthropic collector rewritten against the current `/v1/organizations/usage_report/messages` contract: bucket→results[] schema, `uncached_input_tokens`, `cache_read_input_tokens`, `cache_creation.{ephemeral_5m,ephemeral_1h}_input_tokens`, `has_more`/`next_page` pagination, grouping by model. Cache write tokens = 5m + 1h entries.

Fixture-backed unit tests lock the OpenAI and Anthropic response schemas so future schema drift fails loudly.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` — 11/11 pass (4 new schema fixture tests)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [ ] Exercise OpenAI collector against a real admin API key
- [ ] Exercise Anthropic collector against a real admin API key
- [ ] Spot-check that `llmusage export` emits more than 100k rows on a large DB
- [ ] Spot-check that `llmusage sync --provider codex` picks up runs with repeated token counts

Closes #60
Closes #61
Closes #62
Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)