### PR TITLE
Add strict-mode IDE support for Cursor

### DIFF
--- a/.specs/implementation/ide-support-strict-mode/impl_160426_ide_support_strict.md
+++ b/.specs/implementation/ide-support-strict-mode/impl_160426_ide_support_strict.md
@@ -7,7 +7,7 @@ This change set adds strict-mode IDE support where a real token-bearing local so
 ## Cursor
 
 - Added `src/collectors/cursor.rs`.
-- Source: `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb`.
+- Source: `<config_dir>/Cursor/User/globalStorage/state.vscdb` where `<config_dir>` is `~/Library/Application Support` on macOS and `~/.config` on Linux.
 - Implementation copies the live SQLite DB to `/tmp` before querying to avoid lock conflicts with a running Cursor instance.
 - Reads `cursorDiskKV` rows:
   - `composerData:*` for model configuration

--- a/.specs/implementation/ide-support-strict-mode/impl_160426_ide_support_strict.md
+++ b/.specs/implementation/ide-support-strict-mode/impl_160426_ide_support_strict.md
@@ -1,0 +1,57 @@
+# Implementation Details - IDE Support Strict Mode
+
+## Summary
+
+This change set adds strict-mode IDE support where a real token-bearing local source exists, and codifies explicit non-support where it does not.
+
+## Cursor
+
+- Added `src/collectors/cursor.rs`.
+- Source: `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb`.
+- Implementation copies the live SQLite DB to `/tmp` before querying to avoid lock conflicts with a running Cursor instance.
+- Reads `cursorDiskKV` rows:
+  - `composerData:*` for model configuration
+  - `bubbleId:*` for per-bubble token counts and timing metadata
+- Produces `UsageRecord` rows with:
+  - `provider = "cursor"`
+  - `session_id = <composer_id>`
+  - `input_tokens` / `output_tokens` from persisted Cursor token metadata
+  - timestamp inferred from Cursor client timing fields
+  - metadata including `bubble_id`, `usage_uuid`, and `server_bubble_id`
+
+## Provider Registry Changes
+
+- Registered `cursor` in `src/collectors/mod.rs`.
+- Added provider aliasing:
+  - `antigravity` -> `gemini_cli`
+  - `gemini-cli` -> `gemini_cli`
+  - `vscode-copilot-chat` -> `vscode`
+- Added explicit provider explanations for unsupported or missing providers so `llmusage sync --provider windsurf` and `--provider vscode` fail with actionable strict-mode messages.
+
+## Config / Status Output
+
+- Extended `config --list` output to show:
+  - detected local collectors
+  - unsupported local IDE tooling discovered on disk
+  - strict-mode notes for legacy Antigravity protobuf sessions, Windsurf, and VS Code
+
+## Strict-Mode Outcomes
+
+### Implemented
+
+- `cursor`
+- `gemini_cli` reuse via `antigravity` alias
+
+### Not Implemented
+
+- `windsurf`
+  - local data investigated, but no reliable token-bearing session source found
+- `vscode`
+  - installed AI extensions investigated, but no token-bearing local source found
+- legacy Antigravity protobuf sessions
+  - still not parseable for strict token accounting
+
+## Documentation Updates
+
+- Updated `README.md` supported provider table and architecture section
+- Updated `.specs/prd.md` to reflect Cursor support, Gemini CLI JSONL support, and strict-mode unsupported tooling

--- a/.specs/prd.md
+++ b/.specs/prd.md
@@ -37,7 +37,7 @@ Developers using multiple AI coding assistants (Claude Code, Codex, Cursor, Open
 │   Collectors         │  ← one per source, runs on-demand
 │   ├─ claude_code     │  ← ~/.claude/projects/**/*.jsonl
 │   ├─ codex           │  ← ~/.codex/archived_sessions/*.jsonl
-│   ├─ cursor          │  ← ~/Library/Application Support/Cursor/.../state.vscdb
+│   ├─ cursor          │  ← <config_dir>/Cursor/.../state.vscdb
 │   ├─ opencode        │  ← ~/.local/share/opencode/opencode.db
 │   ├─ gemini_cli      │  ← ~/.gemini/tmp/**/chats/*.jsonl
 │   ├─ anthropic       │  ← API: /v1/organizations/usage
@@ -91,7 +91,7 @@ A UNIQUE index on `(provider, model, input_tokens, output_tokens, cache_read_tok
 
 - **Claude Code**: Parses JSONL session logs from `~/.claude/projects/`. Extracts `message.usage` from assistant messages.
 - **Codex**: Parses JSONL from `~/.codex/archived_sessions/`. Extracts `token_count` events with `last_token_usage` deltas.
-- **Cursor**: Reads local SQLite state from Cursor's `state.vscdb` and extracts per-bubble token counts from persisted Cursor AI metadata.
+- **Cursor**: Reads local SQLite state from `<config_dir>/Cursor/User/globalStorage/state.vscdb` and extracts per-bubble token counts from persisted Cursor AI metadata.
 - **OpenCode**: Reads directly from SQLite at `~/.local/share/opencode/opencode.db`. Message data contains `tokens` and `cost` fields.
 - **Gemini CLI**: Parses JSONL chat session files under `~/.gemini/tmp/**/chats/`.
 
@@ -116,7 +116,7 @@ Pricing is stored as cost-per-token in LiteLLM format and converted to per-milli
 
 ## Configuration
 
-TOML config at `~/.config/llmusage/config.toml` (macOS: `~/Library/Application Support/llmusage/config.toml`).
+TOML config at `<config_dir>/llmusage/config.toml`, where `<config_dir>` resolves to `~/Library/Application Support` on macOS and `~/.config` on Linux.
 
 | Key | Description |
 |-----|-------------|

--- a/.specs/prd.md
+++ b/.specs/prd.md
@@ -6,7 +6,7 @@
 
 ## Problem Statement
 
-Developers using multiple AI coding assistants (Claude Code, Codex, OpenCode, Gemini CLI) and AI APIs (Anthropic, OpenAI, Gemini) have no unified way to track their token consumption and costs. Each tool stores usage data in different formats and locations, making it difficult to answer basic questions like:
+Developers using multiple AI coding assistants (Claude Code, Codex, Cursor, OpenCode, Gemini CLI) and AI APIs (Anthropic, OpenAI, Gemini) have no unified way to track their token consumption and costs. Each tool stores usage data in different formats and locations, making it difficult to answer basic questions like:
 
 - How much am I spending per day/week/month across all tools?
 - Which models consume the most tokens?
@@ -21,7 +21,7 @@ Developers using multiple AI coding assistants (Claude Code, Codex, OpenCode, Ge
 ## Product Goals
 
 1. **Unified collection**: Pull usage data from all major AI coding tools and APIs into one place
-2. **Zero-config for local tools**: Auto-detect installed CLI tools (Claude Code, Codex, OpenCode) without requiring API keys
+2. **Zero-config for local tools**: Auto-detect installed local tools (Claude Code, Codex, Cursor, OpenCode, Gemini CLI JSONL) without requiring API keys
 3. **Accurate pricing**: Use LiteLLM's maintained pricing database (900+ models) with hardcoded fallback
 4. **Fast queries**: SQLite-backed storage with indexed queries for instant reporting
 5. **Simple distribution**: Single binary via `cargo install`, no runtime dependencies
@@ -37,8 +37,9 @@ Developers using multiple AI coding assistants (Claude Code, Codex, OpenCode, Ge
 │   Collectors         │  ← one per source, runs on-demand
 │   ├─ claude_code     │  ← ~/.claude/projects/**/*.jsonl
 │   ├─ codex           │  ← ~/.codex/archived_sessions/*.jsonl
+│   ├─ cursor          │  ← ~/Library/Application Support/Cursor/.../state.vscdb
 │   ├─ opencode        │  ← ~/.local/share/opencode/opencode.db
-│   ├─ gemini_cli      │  ← ~/.gemini/ (protobuf - stub)
+│   ├─ gemini_cli      │  ← ~/.gemini/tmp/**/chats/*.jsonl
 │   ├─ anthropic       │  ← API: /v1/organizations/usage
 │   ├─ openai          │  ← API: /v1/organization/usage
 │   ├─ gemini          │  ← API: stub (no clean usage API)
@@ -90,7 +91,9 @@ A UNIQUE index on `(provider, model, input_tokens, output_tokens, cache_read_tok
 
 - **Claude Code**: Parses JSONL session logs from `~/.claude/projects/`. Extracts `message.usage` from assistant messages.
 - **Codex**: Parses JSONL from `~/.codex/archived_sessions/`. Extracts `token_count` events with `last_token_usage` deltas.
+- **Cursor**: Reads local SQLite state from Cursor's `state.vscdb` and extracts per-bubble token counts from persisted Cursor AI metadata.
 - **OpenCode**: Reads directly from SQLite at `~/.local/share/opencode/opencode.db`. Message data contains `tokens` and `cost` fields.
+- **Gemini CLI**: Parses JSONL chat session files under `~/.gemini/tmp/**/chats/`.
 
 ### Tier 2 - API-based (requires API keys)
 
@@ -98,9 +101,11 @@ A UNIQUE index on `(provider, model, input_tokens, output_tokens, cache_read_tok
 - **OpenAI**: Usage API at `/v1/organization/usage`
 - **Ollama**: Requires explicit `ollama_host` config
 
-### Tier 3 - Stubs (data not accessible)
+### Tier 3 - Strict-mode unsupported
 
-- **Gemini CLI**: Uses protobuf (`.pb`) for conversations - no parseable usage data
+- **Legacy Antigravity protobuf sessions**: Uses protobuf (`.pb`) for conversations - no parseable usage data
+- **Windsurf**: Current local artifacts do not expose reliable token counts
+- **VS Code AI tooling**: Installed extensions expose session/model metadata, but not token counts
 - **Gemini API**: No clean programmatic usage API from Google AI Studio
 
 ## Pricing
@@ -160,6 +165,7 @@ TOML config at `~/.config/llmusage/config.toml` (macOS: `~/Library/Application S
 - No team/multi-user features
 - No real-time streaming collection
 - No proxy-based interception for arbitrary apps
+- No metadata-only collectors in strict mode
 
 ## Future Considerations
 
@@ -167,5 +173,7 @@ TOML config at `~/.config/llmusage/config.toml` (macOS: `~/Library/Application S
 - Interactive TUI with ratatui
 - GitHub Actions integration for CI cost tracking
 - Gemini CLI protobuf reverse-engineering
+- Windsurf usage support if a token-bearing local or API source becomes available
+- VS Code extension support if token-bearing local artifacts become available
 - Cost alerts and budgets
 - Historical cost trend charts

--- a/.specs/tasks/ide-support-strict-mode/task_160426_ide_support_strict.md
+++ b/.specs/tasks/ide-support-strict-mode/task_160426_ide_support_strict.md
@@ -1,0 +1,29 @@
+# Task Record - IDE Support Strict Mode
+
+## Objective
+
+Advance issues `#64`-`#67` using a strict collection bar:
+
+- implement local collectors only when real token counts are available
+- avoid metadata-only collectors for unsupported IDE tooling
+- document strict-mode limitations clearly in code, CLI output, README, and specs
+
+## Scope
+
+- [x] Investigate Cursor local artifacts for token-bearing usage data
+- [x] Investigate Windsurf local artifacts for token-bearing usage data
+- [x] Investigate VS Code AI-tooling local artifacts for token-bearing usage data
+- [x] Reuse existing `gemini_cli` support rather than re-implementing it
+- [x] Add Cursor collector when strict-mode token data is available
+- [x] Add provider alias support for `antigravity -> gemini_cli`
+- [x] Make unsupported providers fail honestly (`windsurf`, `vscode`)
+- [x] Update `config --list` to expose supported vs unsupported local tooling
+- [x] Update README and `.specs/prd.md`
+- [x] Add implementation and validation records for this work
+
+## Decisions
+
+- Cursor is supported because persisted local state contains queryable token counts.
+- Windsurf is not implemented because current local artifacts lack reliable token counts.
+- VS Code is not implemented because installed AI extensions expose session/model metadata but not token counts.
+- Antigravity remains an alias to `gemini_cli`; legacy `.pb` sessions are still unsupported in strict mode.

--- a/.specs/validation/ide-support-strict-mode/validate_160426_ide_support_strict.md
+++ b/.specs/validation/ide-support-strict-mode/validate_160426_ide_support_strict.md
@@ -1,0 +1,43 @@
+# Validation Record - IDE Support Strict Mode
+
+## Build / Lint
+
+### cargo build
+- **Status**: PASS
+
+### cargo clippy --all-targets --all-features -- -D warnings
+- **Status**: PASS
+
+## Targeted Tests
+
+### cargo test cursor
+- **Status**: PASS
+- **Coverage**:
+  - parses Cursor bubble rows into `UsageRecord`
+  - reads a copied temp Cursor SQLite DB and extracts one record
+
+## CLI Smoke Tests
+
+### cargo run -- config --list
+- **Status**: PASS
+- **Verified**:
+  - `cursor` is shown as detected when local Cursor state exists
+  - `windsurf` is shown as unsupported with a strict-mode note when local Windsurf state exists
+  - `vscode` is shown as unsupported with a strict-mode note when local VS Code state exists
+  - `gemini_cli` / legacy Antigravity status is surfaced accurately
+
+### Expected strict-mode provider behavior
+
+- `llmusage sync --provider cursor`
+  - should activate the Cursor collector when local Cursor state exists
+- `llmusage sync --provider antigravity`
+  - should behave the same as `--provider gemini_cli`
+- `llmusage sync --provider windsurf`
+  - should report that Windsurf is unsupported in strict mode because local artifacts do not expose reliable token counts
+- `llmusage sync --provider vscode`
+  - should report that VS Code is unsupported in strict mode because available extension data lacks token counts
+
+## Validation Notes
+
+- Windsurf and VS Code remain intentionally unimplemented under strict mode.
+- The absence of collectors for those providers is expected behavior, not a gap in verification.

--- a/.specs/validation/ide-support-strict-mode/validate_160426_ide_support_strict.md
+++ b/.specs/validation/ide-support-strict-mode/validate_160426_ide_support_strict.md
@@ -15,6 +15,7 @@
 - **Coverage**:
   - parses Cursor bubble rows into `UsageRecord`
   - reads a copied temp Cursor SQLite DB and extracts one record
+  - resolves the Cursor state DB relative to the platform config directory on both macOS and Linux path layouts
 
 ## CLI Smoke Tests
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,19 @@ llmusage collects usage data from multiple AI sources — API dashboards, local 
 |----------|------|-----------------|
 | Claude Code | Local logs (`~/.claude/projects/`) | None (auto-detect) |
 | Codex | Local logs (`~/.codex/archived_sessions/`) | None (auto-detect) |
+| Cursor | Local SQLite (`~/Library/Application Support/Cursor/User/globalStorage/state.vscdb`) | None (auto-detect) |
 | OpenCode | Local SQLite (`~/.local/share/opencode/opencode.db`) | None (auto-detect) |
-| Gemini CLI | Local logs (`~/.gemini/`) | None (stub) |
+| Gemini CLI / Antigravity | Local logs (`~/.gemini/tmp/`) | None (auto-detect) |
 | Anthropic API | REST API | `anthropic_api_key` |
 | OpenAI API | REST API | `openai_api_key` |
 | Gemini API | REST API | `gemini_api_key` (stub) |
 | Ollama | REST API | None (defaults to `localhost:11434`) |
+
+**Strict-mode limitations:**
+
+- `windsurf` is intentionally not supported yet. The local artifacts investigated on macOS did not expose reliable token counts.
+- `vscode` is intentionally not supported as a generic collector. Installed AI extensions exposed session/model metadata, but not token counts.
+- `antigravity` is accepted as a provider alias for `gemini_cli`. Legacy Antigravity `.pb` sessions remain unsupported; only Gemini CLI JSONL sessions are collected.
 
 ## Installation
 
@@ -94,6 +101,7 @@ Pull usage data from all configured and auto-detected providers.
 ```bash
 llmusage sync                    # all providers
 llmusage sync --provider claude_code  # specific provider only
+llmusage sync --provider antigravity  # alias for gemini_cli
 ```
 
 ### Summary
@@ -158,6 +166,8 @@ llmusage config --set ollama_host=http://192.168.1.10:11434
 llmusage config --set claude_code_enabled=false
 ```
 
+`llmusage config --list` also shows auto-detected local collectors and strict-mode unsupported local IDE tooling such as Windsurf and VS Code.
+
 ### Update pricing
 
 Refresh the LiteLLM pricing cache (900+ models).
@@ -214,8 +224,9 @@ SQLite DB (dedup index, WAL mode)
 Collectors (one per source, async)
   ├── claude_code   ~/.claude/projects/**/*.jsonl
   ├── codex         ~/.codex/archived_sessions/*.jsonl
+  ├── cursor        ~/Library/Application Support/Cursor/.../state.vscdb
   ├── opencode      ~/.local/share/opencode/opencode.db
-  ├── gemini_cli    ~/.gemini/ (stub)
+  ├── gemini_cli    ~/.gemini/tmp/**/chats/*.jsonl
   ├── anthropic     /v1/organizations/usage
   ├── openai        /v1/organization/usage
   ├── gemini        (stub)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ llmusage collects usage data from multiple AI sources — API dashboards, local 
 |----------|------|-----------------|
 | Claude Code | Local logs (`~/.claude/projects/`) | None (auto-detect) |
 | Codex | Local logs (`~/.codex/archived_sessions/`) | None (auto-detect) |
-| Cursor | Local SQLite (`~/Library/Application Support/Cursor/User/globalStorage/state.vscdb`) | None (auto-detect) |
+| Cursor | Local SQLite (`<config_dir>/Cursor/User/globalStorage/state.vscdb`) | None (auto-detect) |
 | OpenCode | Local SQLite (`~/.local/share/opencode/opencode.db`) | None (auto-detect) |
 | Gemini CLI / Antigravity | Local logs (`~/.gemini/tmp/`) | None (auto-detect) |
 | Anthropic API | REST API | `anthropic_api_key` |
@@ -168,6 +168,11 @@ llmusage config --set claude_code_enabled=false
 
 `llmusage config --list` also shows auto-detected local collectors and strict-mode unsupported local IDE tooling such as Windsurf and VS Code.
 
+For local SQLite IDE collectors that live under a platform config directory:
+
+- **macOS**: `<config_dir>` resolves to `~/Library/Application Support`
+- **Linux**: `<config_dir>` resolves to `~/.config`
+
 ### Update pricing
 
 Refresh the LiteLLM pricing cache (900+ models).
@@ -224,7 +229,7 @@ SQLite DB (dedup index, WAL mode)
 Collectors (one per source, async)
   ├── claude_code   ~/.claude/projects/**/*.jsonl
   ├── codex         ~/.codex/archived_sessions/*.jsonl
-  ├── cursor        ~/Library/Application Support/Cursor/.../state.vscdb
+  ├── cursor        <config_dir>/Cursor/.../state.vscdb
   ├── opencode      ~/.local/share/opencode/opencode.db
   ├── gemini_cli    ~/.gemini/tmp/**/chats/*.jsonl
   ├── anthropic     /v1/organizations/usage

--- a/src/collectors/cursor.rs
+++ b/src/collectors/cursor.rs
@@ -1,0 +1,416 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use rusqlite::Connection;
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use super::Collector;
+use crate::costs;
+use crate::models::UsageRecord;
+
+pub struct CursorCollector {
+    db_path: PathBuf,
+}
+
+impl Default for CursorCollector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CursorCollector {
+    pub fn new() -> Self {
+        Self {
+            db_path: cursor_state_db_path(),
+        }
+    }
+
+    #[cfg(test)]
+    fn with_db_path(db_path: PathBuf) -> Self {
+        Self { db_path }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ComposerData {
+    #[serde(default, rename = "modelConfig")]
+    model_config: Option<ModelConfig>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ModelConfig {
+    #[serde(default, rename = "modelName")]
+    model_name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BubbleData {
+    #[serde(default, rename = "tokenCount")]
+    token_count: Option<TokenCount>,
+    #[serde(default, rename = "timingInfo")]
+    timing_info: Option<TimingInfo>,
+    #[serde(default, rename = "usageUuid")]
+    usage_uuid: Option<String>,
+    #[serde(default, rename = "serverBubbleId")]
+    server_bubble_id: Option<String>,
+    #[serde(default)]
+    text: Option<String>,
+    #[serde(default, rename = "isAgentic")]
+    is_agentic: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TokenCount {
+    #[serde(default, rename = "inputTokens")]
+    input_tokens: i64,
+    #[serde(default, rename = "outputTokens")]
+    output_tokens: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct TimingInfo {
+    #[serde(default, rename = "clientEndTime")]
+    client_end_time: Option<i64>,
+    #[serde(default, rename = "clientSettleTime")]
+    client_settle_time: Option<i64>,
+    #[serde(default, rename = "clientStartTime")]
+    client_start_time: Option<i64>,
+}
+
+#[async_trait]
+impl Collector for CursorCollector {
+    fn name(&self) -> &str {
+        "cursor"
+    }
+
+    async fn collect(&self) -> Result<Vec<UsageRecord>> {
+        if !self.db_path.exists() {
+            return Ok(vec![]);
+        }
+
+        let temp_db = copy_to_temp(&self.db_path, "cursor-state.vscdb")?;
+        let collected_at = Utc::now().to_rfc3339();
+        let conn = Connection::open(&temp_db)?;
+        if !has_cursor_disk_kv(&conn)? {
+            let _ = std::fs::remove_file(temp_db);
+            return Ok(vec![]);
+        }
+
+        let model_names = load_model_names(&conn)?;
+        let mut stmt = conn.prepare(
+            "SELECT key, CAST(value AS TEXT)
+             FROM cursorDiskKV
+             WHERE key LIKE 'bubbleId:%'
+               AND (
+                 COALESCE(json_extract(CAST(value AS TEXT), '$.tokenCount.inputTokens'), 0) > 0
+                 OR COALESCE(json_extract(CAST(value AS TEXT), '$.tokenCount.outputTokens'), 0) > 0
+               )",
+        )?;
+
+        let rows = stmt.query_map([], |row| {
+            let key: String = row.get(0)?;
+            let payload: Option<String> = row.get(1)?;
+            Ok((key, payload))
+        })?;
+
+        let mut records = Vec::new();
+        for row in rows {
+            let (key, payload) = row?;
+            let Some(payload) = payload else {
+                continue;
+            };
+            if let Some(record) = parse_bubble_row(&key, &payload, &collected_at, &model_names)? {
+                records.push(record);
+            }
+        }
+
+        let _ = std::fs::remove_file(temp_db);
+        Ok(records)
+    }
+}
+
+pub fn cursor_state_db_path() -> PathBuf {
+    dirs::config_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("Cursor")
+        .join("User")
+        .join("globalStorage")
+        .join("state.vscdb")
+}
+
+fn copy_to_temp(source: &Path, suffix: &str) -> Result<PathBuf> {
+    let temp_path =
+        std::env::temp_dir().join(format!("llmusage-{}-{}", std::process::id(), suffix));
+    std::fs::copy(source, &temp_path)?;
+    Ok(temp_path)
+}
+
+fn has_cursor_disk_kv(conn: &Connection) -> Result<bool> {
+    let exists = conn.query_row(
+        "SELECT EXISTS(
+            SELECT 1
+            FROM sqlite_master
+            WHERE type = 'table' AND name = 'cursorDiskKV'
+        )",
+        [],
+        |row| row.get::<_, i64>(0),
+    )?;
+    Ok(exists == 1)
+}
+
+fn load_model_names(conn: &Connection) -> Result<HashMap<String, String>> {
+    let mut model_names = HashMap::new();
+    let mut stmt = conn.prepare(
+        "SELECT key, CAST(value AS TEXT)
+         FROM cursorDiskKV
+         WHERE key LIKE 'composerData:%'",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        let key: String = row.get(0)?;
+        let payload: Option<String> = row.get(1)?;
+        Ok((key, payload))
+    })?;
+
+    for row in rows {
+        let (key, payload) = row?;
+        let Some(payload) = payload else {
+            continue;
+        };
+        let Some(composer_id) = key.strip_prefix("composerData:") else {
+            continue;
+        };
+        let parsed: ComposerData = match serde_json::from_str(&payload) {
+            Ok(value) => value,
+            Err(_) => continue,
+        };
+        if let Some(model_name) = parsed
+            .model_config
+            .and_then(|cfg| cfg.model_name)
+            .filter(|name| !name.trim().is_empty())
+        {
+            model_names.insert(composer_id.to_string(), model_name);
+        }
+    }
+
+    Ok(model_names)
+}
+
+fn parse_bubble_row(
+    key: &str,
+    payload: &str,
+    collected_at: &str,
+    model_names: &HashMap<String, String>,
+) -> Result<Option<UsageRecord>> {
+    let Some(raw_ids) = key.strip_prefix("bubbleId:") else {
+        return Ok(None);
+    };
+    let Some((composer_id, bubble_id)) = raw_ids.split_once(':') else {
+        return Ok(None);
+    };
+
+    let parsed: BubbleData = match serde_json::from_str(payload) {
+        Ok(value) => value,
+        Err(_) => return Ok(None),
+    };
+
+    let Some(token_count) = parsed.token_count.as_ref() else {
+        return Ok(None);
+    };
+    if token_count.input_tokens == 0 && token_count.output_tokens == 0 {
+        return Ok(None);
+    }
+
+    let model = model_names
+        .get(composer_id)
+        .cloned()
+        .unwrap_or_else(|| "cursor-default".to_string());
+    let recorded_at = bubble_recorded_at(&parsed).unwrap_or_else(|| Utc::now().to_rfc3339());
+    let cost_usd = infer_priced_provider(&model).and_then(|provider| {
+        costs::calculate_cost(
+            &model,
+            provider,
+            token_count.input_tokens,
+            token_count.output_tokens,
+            0,
+            0,
+        )
+    });
+    let metadata = serde_json::to_string(&serde_json::json!({
+        "bubble_id": bubble_id,
+        "usage_uuid": parsed.usage_uuid,
+        "server_bubble_id": parsed.server_bubble_id,
+        "is_agentic": parsed.is_agentic,
+        "preview": parsed.text.as_deref().map(trim_preview),
+    }))
+    .ok();
+
+    Ok(Some(UsageRecord {
+        id: None,
+        provider: "cursor".to_string(),
+        model,
+        input_tokens: token_count.input_tokens,
+        output_tokens: token_count.output_tokens,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+        cost_usd,
+        session_id: Some(composer_id.to_string()),
+        recorded_at,
+        collected_at: collected_at.to_string(),
+        metadata,
+    }))
+}
+
+fn bubble_recorded_at(parsed: &BubbleData) -> Option<String> {
+    let millis = parsed
+        .timing_info
+        .as_ref()
+        .and_then(|info| info.client_end_time)
+        .or_else(|| {
+            parsed
+                .timing_info
+                .as_ref()
+                .and_then(|info| info.client_settle_time)
+        })
+        .or_else(|| {
+            parsed
+                .timing_info
+                .as_ref()
+                .and_then(|info| info.client_start_time)
+        })?;
+
+    DateTime::from_timestamp_millis(millis).map(|ts| ts.to_rfc3339())
+}
+
+fn infer_priced_provider(model: &str) -> Option<&'static str> {
+    let normalized = model.strip_prefix("cursor-").unwrap_or(model);
+    if normalized.starts_with("claude") {
+        Some("anthropic")
+    } else if normalized.starts_with("gpt")
+        || normalized.starts_with("o1")
+        || normalized.starts_with("o3")
+    {
+        Some("openai")
+    } else if normalized.starts_with("gemini") {
+        Some("gemini")
+    } else {
+        None
+    }
+}
+
+fn trim_preview(text: &str) -> String {
+    const LIMIT: usize = 160;
+    let trimmed = text.trim();
+    if trimmed.chars().count() <= LIMIT {
+        trimmed.to_string()
+    } else {
+        let preview: String = trimmed.chars().take(LIMIT).collect();
+        format!("{}...", preview)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn temp_file(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!("llmusage-test-{}-{}", std::process::id(), name))
+    }
+
+    #[test]
+    fn parses_cursor_bubble_row() {
+        let mut model_names = HashMap::new();
+        model_names.insert("composer-1".to_string(), "gpt-4.1".to_string());
+
+        let payload = serde_json::json!({
+            "tokenCount": {
+                "inputTokens": 1200,
+                "outputTokens": 300
+            },
+            "timingInfo": {
+                "clientEndTime": 1741448289691_i64
+            },
+            "usageUuid": "usage-1",
+            "serverBubbleId": "server-1",
+            "isAgentic": true,
+            "text": "A fairly long assistant response"
+        })
+        .to_string();
+
+        let record = parse_bubble_row(
+            "bubbleId:composer-1:bubble-1",
+            &payload,
+            "2026-04-16T12:00:00Z",
+            &model_names,
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(record.provider, "cursor");
+        assert_eq!(record.model, "gpt-4.1");
+        assert_eq!(record.input_tokens, 1200);
+        assert_eq!(record.output_tokens, 300);
+        assert_eq!(record.session_id.as_deref(), Some("composer-1"));
+        assert!(record.recorded_at.starts_with("2025-03-"));
+        assert!(record
+            .metadata
+            .as_deref()
+            .unwrap_or("")
+            .contains("\"bubble_id\":\"bubble-1\""));
+    }
+
+    #[tokio::test]
+    async fn collector_reads_temp_copied_cursor_db() {
+        let db_path = temp_file("cursor-state.vscdb");
+        let _ = fs::remove_file(&db_path);
+
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute("CREATE TABLE cursorDiskKV (key TEXT, value BLOB)", [])
+            .unwrap();
+        conn.execute(
+            "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+            (
+                "composerData:composer-1",
+                serde_json::json!({
+                    "modelConfig": {
+                        "modelName": "gpt-4.1"
+                    }
+                })
+                .to_string(),
+            ),
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+            (
+                "bubbleId:composer-1:bubble-1",
+                serde_json::json!({
+                    "tokenCount": {
+                        "inputTokens": 42,
+                        "outputTokens": 9
+                    },
+                    "timingInfo": {
+                        "clientEndTime": 1741448289691_i64
+                    },
+                    "text": "hello"
+                })
+                .to_string(),
+            ),
+        )
+        .unwrap();
+        drop(conn);
+
+        let collector = CursorCollector::with_db_path(db_path.clone());
+        let records = collector.collect().await.unwrap();
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].provider, "cursor");
+        assert_eq!(records[0].model, "gpt-4.1");
+        assert_eq!(records[0].input_tokens, 42);
+        assert_eq!(records[0].output_tokens, 9);
+
+        let _ = fs::remove_file(db_path);
+    }
+}

--- a/src/collectors/cursor.rs
+++ b/src/collectors/cursor.rs
@@ -132,8 +132,11 @@ impl Collector for CursorCollector {
 }
 
 pub fn cursor_state_db_path() -> PathBuf {
-    dirs::config_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
+    cursor_state_db_path_from_config_dir(&dirs::config_dir().unwrap_or_else(|| PathBuf::from(".")))
+}
+
+fn cursor_state_db_path_from_config_dir(config_dir: &Path) -> PathBuf {
+    config_dir
         .join("Cursor")
         .join("User")
         .join("globalStorage")
@@ -317,6 +320,25 @@ mod tests {
 
     fn temp_file(name: &str) -> PathBuf {
         std::env::temp_dir().join(format!("llmusage-test-{}-{}", std::process::id(), name))
+    }
+
+    #[test]
+    fn cursor_state_path_is_relative_to_platform_config_dir() {
+        let macos = cursor_state_db_path_from_config_dir(Path::new(
+            "/Users/alice/Library/Application Support",
+        ));
+        assert_eq!(
+            macos,
+            PathBuf::from(
+                "/Users/alice/Library/Application Support/Cursor/User/globalStorage/state.vscdb"
+            )
+        );
+
+        let linux = cursor_state_db_path_from_config_dir(Path::new("/home/alice/.config"));
+        assert_eq!(
+            linux,
+            PathBuf::from("/home/alice/.config/Cursor/User/globalStorage/state.vscdb")
+        );
     }
 
     #[test]

--- a/src/collectors/mod.rs
+++ b/src/collectors/mod.rs
@@ -1,6 +1,7 @@
 pub mod anthropic;
 pub mod claude_code;
 pub mod codex;
+pub mod cursor;
 pub mod gemini;
 pub mod gemini_cli;
 pub mod ollama;
@@ -9,6 +10,7 @@ pub mod opencode;
 
 use anyhow::Result;
 use async_trait::async_trait;
+use std::path::PathBuf;
 
 use crate::config::Config;
 use crate::models::UsageRecord;
@@ -19,10 +21,25 @@ pub trait Collector: Send + Sync {
     async fn collect(&self) -> Result<Vec<UsageRecord>>;
 }
 
+pub struct LocalCollectorStatus {
+    pub name: &'static str,
+    pub state: LocalCollectorState,
+    pub path: PathBuf,
+    pub note: Option<&'static str>,
+}
+
+#[derive(Clone, Copy)]
+pub enum LocalCollectorState {
+    Detected,
+    NotFound,
+    Unsupported,
+}
+
 pub fn get_collectors(
     cfg: &Config,
     provider_filter: Option<&str>,
 ) -> Result<Vec<Box<dyn Collector>>> {
+    let provider_filter = provider_filter.map(canonical_provider_name);
     let mut collectors: Vec<Box<dyn Collector>> = Vec::new();
 
     let should_include = |name: &str| provider_filter.is_none() || provider_filter == Some(name);
@@ -60,35 +77,243 @@ pub fn get_collectors(
     }
 
     if should_include("codex") {
-        let codex_dir = dirs::home_dir()
-            .unwrap_or_default()
-            .join(".codex")
-            .join("archived_sessions");
+        let codex_dir = codex_sessions_dir();
         if codex_dir.exists() {
             collectors.push(Box::new(codex::CodexCollector::new()));
         }
     }
 
     if should_include("opencode") {
-        let db_path = dirs::home_dir()
-            .unwrap_or_default()
-            .join(".local/share/opencode/opencode.db");
+        let db_path = opencode_db_path();
         if db_path.exists() {
             collectors.push(Box::new(opencode::OpenCodeCollector::new()));
         }
     }
 
     if should_include("gemini_cli") {
-        let home = dirs::home_dir().unwrap_or_default();
-        let jsonl_dir = home.join(".gemini").join("tmp");
-        let legacy_dir = home
-            .join(".gemini")
-            .join("antigravity")
-            .join("conversations");
+        let jsonl_dir = gemini_cli_jsonl_dir();
+        let legacy_dir = gemini_cli_legacy_dir();
         if jsonl_dir.exists() || legacy_dir.exists() {
             collectors.push(Box::new(gemini_cli::GeminiCliCollector::new()));
         }
     }
 
+    if should_include("cursor") {
+        let db_path = cursor::cursor_state_db_path();
+        if db_path.exists() {
+            collectors.push(Box::new(cursor::CursorCollector::new()));
+        }
+    }
+
     Ok(collectors)
+}
+
+pub fn local_collector_statuses() -> Vec<LocalCollectorStatus> {
+    let gemini_dir = gemini_cli_jsonl_dir();
+    let gemini_legacy_dir = gemini_cli_legacy_dir();
+    let gemini_jsonl_detected = gemini_dir.exists();
+    let gemini_legacy_detected = gemini_legacy_dir.exists();
+
+    vec![
+        LocalCollectorStatus {
+            name: "codex",
+            state: if codex_sessions_dir().exists() {
+                LocalCollectorState::Detected
+            } else {
+                LocalCollectorState::NotFound
+            },
+            path: codex_sessions_dir(),
+            note: None,
+        },
+        LocalCollectorStatus {
+            name: "opencode",
+            state: if opencode_db_path().exists() {
+                LocalCollectorState::Detected
+            } else {
+                LocalCollectorState::NotFound
+            },
+            path: opencode_db_path(),
+            note: None,
+        },
+        LocalCollectorStatus {
+            name: "gemini_cli",
+            state: if gemini_jsonl_detected {
+                LocalCollectorState::Detected
+            } else if gemini_legacy_detected {
+                LocalCollectorState::Unsupported
+            } else {
+                LocalCollectorState::NotFound
+            },
+            path: if gemini_jsonl_detected {
+                gemini_dir
+            } else {
+                gemini_legacy_dir
+            },
+            note: if gemini_legacy_detected && !gemini_jsonl_detected {
+                Some("legacy Antigravity .pb sessions are not parseable in strict mode")
+            } else {
+                None
+            },
+        },
+        LocalCollectorStatus {
+            name: "cursor",
+            state: if cursor::cursor_state_db_path().exists() {
+                LocalCollectorState::Detected
+            } else {
+                LocalCollectorState::NotFound
+            },
+            path: cursor::cursor_state_db_path(),
+            note: None,
+        },
+        LocalCollectorStatus {
+            name: "windsurf",
+            state: if windsurf_state_db_path().exists() {
+                LocalCollectorState::Unsupported
+            } else {
+                LocalCollectorState::NotFound
+            },
+            path: windsurf_state_db_path(),
+            note: Some("local data lacks reliable token counts"),
+        },
+        LocalCollectorStatus {
+            name: "vscode",
+            state: if vscode_state_db_path().exists() {
+                LocalCollectorState::Unsupported
+            } else {
+                LocalCollectorState::NotFound
+            },
+            path: vscode_state_db_path(),
+            note: Some("installed AI extensions lack local token counts"),
+        },
+    ]
+}
+
+pub fn canonical_provider_name(name: &str) -> &str {
+    match name {
+        "antigravity" | "gemini-cli" => "gemini_cli",
+        "vscode-copilot-chat" => "vscode",
+        _ => name,
+    }
+}
+
+pub fn explain_provider_filter(cfg: &Config, provider_filter: &str) -> String {
+    match canonical_provider_name(provider_filter) {
+        "anthropic" => {
+            if cfg.anthropic_api_key.is_some() {
+                "Provider 'anthropic' is configured but returned no active collector.".to_string()
+            } else {
+                "Provider 'anthropic' is supported but requires `anthropic_api_key` in config."
+                    .to_string()
+            }
+        }
+        "openai" => {
+            if cfg.openai_api_key.is_some() {
+                "Provider 'openai' is configured but returned no active collector.".to_string()
+            } else {
+                "Provider 'openai' is supported but requires `openai_api_key` in config."
+                    .to_string()
+            }
+        }
+        "gemini" => {
+            if cfg.gemini_api_key.is_some() {
+                "Provider 'gemini' is configured, but the Gemini API collector remains unimplemented."
+                    .to_string()
+            } else {
+                "Provider 'gemini' is supported only as a stub and also requires `gemini_api_key` in config."
+                    .to_string()
+            }
+        }
+        "ollama" => "Provider 'ollama' is supported, but no collector could be activated.".to_string(),
+        "claude_code" => {
+            if cfg.claude_code_enabled {
+                "Provider 'claude_code' is enabled, but no local session logs were found."
+                    .to_string()
+            } else {
+                "Provider 'claude_code' is supported but currently disabled in config."
+                    .to_string()
+            }
+        }
+        "codex" => {
+            "Provider 'codex' is supported but no `~/.codex/archived_sessions` logs were found."
+                .to_string()
+        }
+        "opencode" => {
+            "Provider 'opencode' is supported but no local OpenCode database was found."
+                .to_string()
+        }
+        "gemini_cli" => {
+            if gemini_cli_jsonl_dir().exists() {
+                "Provider 'gemini_cli' is supported but no collector could be activated."
+                    .to_string()
+            } else if gemini_cli_legacy_dir().exists() {
+                "Provider 'antigravity' legacy `.pb` sessions are present, but strict mode requires parseable token counts; only Gemini CLI JSONL sessions are supported."
+                    .to_string()
+            } else {
+                "Provider 'gemini_cli' is supported but no local Gemini CLI session data was found."
+                    .to_string()
+            }
+        }
+        "cursor" => {
+            "Provider 'cursor' is supported but no local Cursor state database was found."
+                .to_string()
+        }
+        "windsurf" => {
+            "Provider 'windsurf' is not supported in strict mode because local artifacts do not expose reliable token counts."
+                .to_string()
+        }
+        "vscode" => {
+            "Provider 'vscode' is not supported in strict mode because available extension data lacks token counts."
+                .to_string()
+        }
+        other => format!(
+            "Unknown provider '{}'. Known providers: anthropic, openai, gemini, ollama, claude_code, codex, opencode, gemini_cli, antigravity, cursor, windsurf, vscode",
+            other
+        ),
+    }
+}
+
+fn codex_sessions_dir() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_default()
+        .join(".codex")
+        .join("archived_sessions")
+}
+
+fn opencode_db_path() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_default()
+        .join(".local/share/opencode/opencode.db")
+}
+
+fn gemini_cli_jsonl_dir() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_default()
+        .join(".gemini")
+        .join("tmp")
+}
+
+fn gemini_cli_legacy_dir() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_default()
+        .join(".gemini")
+        .join("antigravity")
+        .join("conversations")
+}
+
+fn windsurf_state_db_path() -> PathBuf {
+    dirs::config_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("Windsurf")
+        .join("User")
+        .join("globalStorage")
+        .join("state.vscdb")
+}
+
+fn vscode_state_db_path() -> PathBuf {
+    dirs::config_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("Code")
+        .join("User")
+        .join("globalStorage")
+        .join("state.vscdb")
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,14 +139,19 @@ async fn main() -> Result<()> {
 
     match cli.command {
         Commands::Sync { provider } => {
-            cmd_sync(&cfg, &db, provider.as_deref()).await?;
+            cmd_sync(&cfg, &db, canonical_provider_filter(provider.as_deref())).await?;
         }
         Commands::Summary {
             days,
             provider,
             model,
         } => {
-            cmd_summary(&db, days, provider.as_deref(), model.as_deref())?;
+            cmd_summary(
+                &db,
+                days,
+                canonical_provider_filter(provider.as_deref()),
+                model.as_deref(),
+            )?;
         }
         Commands::Daily {
             days,
@@ -154,7 +159,13 @@ async fn main() -> Result<()> {
             json,
             all,
         } => {
-            cmd_daily(&db, days, provider.as_deref(), json, all)?;
+            cmd_daily(
+                &db,
+                days,
+                canonical_provider_filter(provider.as_deref()),
+                json,
+                all,
+            )?;
         }
         Commands::Weekly {
             weeks,
@@ -162,7 +173,13 @@ async fn main() -> Result<()> {
             json,
             all,
         } => {
-            cmd_weekly(&db, weeks, provider.as_deref(), json, all)?;
+            cmd_weekly(
+                &db,
+                weeks,
+                canonical_provider_filter(provider.as_deref()),
+                json,
+                all,
+            )?;
         }
         Commands::Monthly {
             months,
@@ -170,7 +187,13 @@ async fn main() -> Result<()> {
             json,
             all,
         } => {
-            cmd_monthly(&db, months, provider.as_deref(), json, all)?;
+            cmd_monthly(
+                &db,
+                months,
+                canonical_provider_filter(provider.as_deref()),
+                json,
+                all,
+            )?;
         }
         Commands::Detail {
             model,
@@ -182,14 +205,14 @@ async fn main() -> Result<()> {
             cmd_detail(
                 &db,
                 model.as_deref(),
-                provider.as_deref(),
+                canonical_provider_filter(provider.as_deref()),
                 since.as_deref(),
                 until.as_deref(),
                 limit,
             )?;
         }
         Commands::Models { provider } => {
-            cmd_models(provider.as_deref())?;
+            cmd_models(canonical_provider_filter(provider.as_deref()))?;
         }
         Commands::UpdatePricing => {
             cmd_update_pricing().await?;
@@ -232,11 +255,18 @@ async fn cmd_sync(
     let providers = collectors::get_collectors(cfg, provider_filter)?;
 
     if providers.is_empty() {
-        println!(
-            "{}",
-            "No providers configured. Run `llmusage config --set anthropic_api_key=sk-...`"
-                .yellow()
-        );
+        if let Some(filter) = provider_filter {
+            println!(
+                "{}",
+                collectors::explain_provider_filter(cfg, filter).yellow()
+            );
+        } else {
+            println!(
+                "{}",
+                "No providers configured. Run `llmusage config --set anthropic_api_key=sk-...`"
+                    .yellow()
+            );
+        }
         return Ok(());
     }
 
@@ -342,6 +372,8 @@ fn cmd_models(provider: Option<&str>) -> Result<()> {
 }
 
 fn cmd_config(cfg: &config::Config, set: Option<&str>, _list: bool) -> Result<()> {
+    use colored::Colorize;
+
     if let Some(kv) = set {
         let (key, value) = kv
             .split_once('=')
@@ -350,8 +382,37 @@ fn cmd_config(cfg: &config::Config, set: Option<&str>, _list: bool) -> Result<()
         println!("Set {} = {}", key.trim(), value.trim());
     } else {
         config::print_config(cfg);
+        println!();
+        println!("{}", "Local collectors (auto-detected):".bold());
+        for status in collectors::local_collector_statuses() {
+            let label = match status.state {
+                collectors::LocalCollectorState::Detected => "detected".green(),
+                collectors::LocalCollectorState::NotFound => "not found".dimmed(),
+                collectors::LocalCollectorState::Unsupported => "unsupported".yellow(),
+            };
+            if let Some(note) = status.note {
+                println!(
+                    "  {:<12} {} ({}) - {}",
+                    status.name,
+                    label,
+                    status.path.display(),
+                    note
+                );
+            } else {
+                println!(
+                    "  {:<12} {} ({})",
+                    status.name,
+                    label,
+                    status.path.display()
+                );
+            }
+        }
     }
     Ok(())
+}
+
+fn canonical_provider_filter(provider: Option<&str>) -> Option<&str> {
+    provider.map(collectors::canonical_provider_name)
 }
 
 async fn cmd_update_pricing() -> Result<()> {


### PR DESCRIPTION
## What changed

This PR adds strict-mode IDE support work for issues #64-#67.

- adds a new `cursor` collector backed by Cursor's local `state.vscdb`
- extracts persisted Cursor token counts into `UsageRecord` rows
- adds strict-mode provider handling for `windsurf` and `vscode` so they fail with explicit unsupported messages instead of generic config errors
- aliases `antigravity` to the existing `gemini_cli` collector path
- extends `config --list` to show detected local collectors and strict-mode unsupported local IDE tooling
- updates README and `.specs` to reflect the implementation and the strict-mode non-goals

## Why

The goal was to continue the IDE-support work with a strict bar: only implement local collectors when real token counts are available.

On this machine:

- Cursor exposed queryable persisted token counts in local SQLite state, so it was implemented.
- Windsurf did not expose a reliable local token-bearing session source.
- VS Code itself is not a source, and the installed AI extensions exposed session/model metadata but not token counts.
- Legacy Antigravity protobuf sessions remain unsupported under strict mode.

## Impact

- users with local Cursor history can now sync Cursor usage with `llmusage sync --provider cursor`
- `llmusage sync --provider windsurf` and `--provider vscode` now explain why they are unsupported in strict mode
- `llmusage sync --provider antigravity` routes through `gemini_cli`
- `llmusage config --list` now makes supported vs unsupported local IDE tooling visible

## Validation

- `cargo build`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test cursor`
- `cargo run -- config --list`
- `cargo run -- sync --provider windsurf`
- `cargo run -- sync --provider vscode`
- `cargo run -- sync --provider antigravity`

## Issue Links

Closes #64
Closes #65
Closes #66
Closes #67

Related:
- #19

## Notes

This PR intentionally does not add metadata-only collectors for Windsurf or VS Code. The strict-mode requirement is preserved.