### PR TITLE
Add curl | sh installer script

### DIFF
--- a/.specs/implementation/install-script/impl_170426_install_script.md
+++ b/.specs/implementation/install-script/impl_170426_install_script.md
@@ -1,0 +1,89 @@
+# Implementation Details - curl | sh Installer Script
+
+## Summary
+
+Adds `install.sh` at the repo root. The script downloads the correct prebuilt release tarball for the host's OS/arch/libc, verifies it against the release's `sha256sums.txt`, and drops the `llmusage` binary into a bin directory. It replaces `cargo install llmusage` as the recommended install path for users who do not have a Rust or C toolchain.
+
+## File Layout
+
+- `install.sh` (new) — POSIX `sh` script, executable bit set, shellcheck-clean.
+- `README.md` — install section rewritten to lead with the installer and document C toolchain requirements for the remaining install paths.
+- `.specs/prd.md` — distribution section updated.
+
+## Script Behavior
+
+### Platform detection
+
+- `uname -s` → `Linux` or `Darwin`
+- `uname -m` → `x86_64`, `amd64`, `aarch64`, or `arm64`
+- On Linux, libc is detected via `ldd --version 2>&1 | grep -qi musl` and an `/etc/alpine-release` fallback to choose between:
+  - `x86_64-unknown-linux-gnu`
+  - `x86_64-unknown-linux-musl`
+  - `aarch64-unknown-linux-gnu`
+- On macOS, arm64 and x86_64 both map to the corresponding `-apple-darwin` tarball.
+- Any other OS exits with a message pointing the user at `cargo install llmusage`.
+
+### Tooling fallbacks
+
+- HTTP fetch: `curl -fsSL` preferred, `wget -qO-` fallback.
+- Checksum: `sha256sum` preferred (Linux default), `shasum -a 256` fallback (macOS default).
+- The script errors out immediately if none of `uname`, `tar`, `mkdir`, a downloader, or a hasher is available.
+
+### Version resolution
+
+- Default: call `https://api.github.com/repos/openrijal/llmusage/releases/latest` and parse `tag_name` via `sed`.
+- Override: `LLMUSAGE_VERSION=vX.Y.Z` env var skips the API call.
+
+### Install location
+
+| Condition | Directory |
+|---|---|
+| `LLMUSAGE_INSTALL_DIR` is set | that path |
+| Running as root (`id -u == 0`) | `/usr/local/bin` |
+| Otherwise | `$HOME/.local/bin` |
+
+### Checksum verification
+
+- Downloads `sha256sums.txt` from the same release.
+- Extracts the expected hash with `awk -v f="$TARBALL" '$2 == f {print $1}'`.
+- Compares against the actual hash of the downloaded tarball.
+- Mismatch exits with a clear error showing both values.
+
+### Installation
+
+- Extracts the tarball into a `mktemp -d` working directory cleaned up via `trap`.
+- Verifies the extracted `llmusage` binary exists.
+- `mv -f` into the install dir; if the move fails (permissions), exits with a hint to run `sudo sh` or set `LLMUSAGE_INSTALL_DIR`.
+- `chmod +x` on the destination.
+
+### PATH awareness
+
+- Detects whether the install dir is already on `PATH` by scanning `:$PATH:`.
+- If not, prints the exact shell rc line the user should add. Does not modify any shell rc files.
+
+## README Changes
+
+Install section now leads with the installer:
+
+```bash
+curl -LsSf https://raw.githubusercontent.com/openrijal/llmusage/main/install.sh | sh
+```
+
+The `cargo install` section is retained but explicitly documents the C toolchain requirement with distro-specific commands for Debian/Ubuntu, Arch, Alpine, and macOS.
+
+The uninstall section documents the new install-script removal path:
+
+```bash
+rm "$HOME/.local/bin/llmusage"   # or /usr/local/bin/llmusage when installed as root
+```
+
+## PRD Changes
+
+- Distribution section lists the install script as the primary path, with `cargo install` and Homebrew as secondary.
+- Notes the C toolchain caveat for `cargo install`.
+
+## Out of Scope
+
+- Windows support — the release pipeline does not currently produce Windows binaries.
+- Auto-updating `PATH` in shell rc files.
+- Hosting the installer at a custom domain or a shortened URL.

--- a/.specs/prd.md
+++ b/.specs/prd.md
@@ -154,9 +154,11 @@ TOML config at `<config_dir>/llmusage/config.toml`, where `<config_dir>` resolve
 
 ## Distribution
 
-- `cargo install llmusage` from crates.io
+- `curl -LsSf https://raw.githubusercontent.com/openrijal/llmusage/main/install.sh | sh` — primary path; downloads a prebuilt binary, no Rust or C toolchain required
+- `brew install openrijal/tap/llmusage` — macOS Homebrew tap
+- `cargo install llmusage` from crates.io — builds from source; requires the Rust toolchain and a working C compiler because `rusqlite` bundles SQLite
 - Single static binary, no runtime dependencies (SQLite bundled)
-- Works on macOS and Linux
+- Works on macOS (Intel & Apple Silicon) and Linux (x86_64 glibc, x86_64 musl, aarch64)
 
 ## Non-Goals (v0.1)
 

--- a/.specs/tasks/install-script/task_170426_install_script.md
+++ b/.specs/tasks/install-script/task_170426_install_script.md
@@ -1,0 +1,28 @@
+# Task Record - curl | sh Installer Script
+
+## Objective
+
+Provide a zero-dependency install path that does not require a Rust or C toolchain.
+
+A developer reported that `cargo install llmusage` failed on Linux while compiling `rusqlite`'s bundled SQLite with a `cc` error. The crate's dependency set has not changed between `v0.1.1` and `v0.1.2` — only the version number — but `cargo install` re-resolves transitive deps on every run and always needs a C toolchain for any crate with native code. Users without `build-essential` / `base-devel` / Xcode Command Line Tools will hit this.
+
+## Scope
+
+- [x] Ship `install.sh` at the repo root that downloads the prebuilt release tarball for the user's platform and installs the binary
+- [x] Detect OS (Linux / macOS) and arch (`x86_64`, `aarch64` / `arm64`)
+- [x] Detect Linux libc (glibc vs musl) and pick the right release asset
+- [x] Verify the downloaded tarball against `sha256sums.txt` before installing
+- [x] Default install location: `/usr/local/bin` when root, `$HOME/.local/bin` otherwise
+- [x] Support overrides via `LLMUSAGE_VERSION` and `LLMUSAGE_INSTALL_DIR` environment variables
+- [x] Work with either `curl` or `wget`, and either `sha256sum` or `shasum`
+- [x] Pass `shellcheck` with no warnings
+- [x] Update `README.md` to lead with the install script, call out the C toolchain requirement for `cargo install`, and note the new uninstall path
+- [x] Update `.specs/prd.md` distribution section
+
+## Decisions
+
+- The script is hosted from `raw.githubusercontent.com/openrijal/llmusage/main/install.sh` rather than attached to each release, so a single file stays authoritative and improvements reach users without re-cutting a release.
+- sha256 verification is mandatory, not optional — a `curl | sh` script without checksum verification is an unacceptable supply-chain footgun.
+- Install dir defaults to `$HOME/.local/bin` for non-root runs rather than prompting for `sudo`, because the common `curl | sh` flow is non-interactive.
+- Scope is explicitly limited to **Linux and macOS**. Windows users are directed to `cargo install` or the prebuilt Windows binary (future work once a Windows target is added to the release pipeline).
+- The script does not attempt to add the install dir to `PATH`; it prints a warning with the exact line to append to the user's shell rc file. Modifying shell rc files from an installer invites edge cases (multiple shells, existing entries, sourcing order) that are not worth the complexity for a binary drop-in.

--- a/.specs/validation/install-script/validate_170426_install_script.md
+++ b/.specs/validation/install-script/validate_170426_install_script.md
@@ -1,0 +1,59 @@
+# Validation Record - curl | sh Installer Script
+
+## Static Analysis
+
+### shellcheck install.sh
+- **Status**: PASS
+- No warnings or notes.
+
+### bash -n install.sh
+- **Status**: PASS
+- POSIX syntax is clean.
+
+## End-to-End Install
+
+### macOS (aarch64-apple-darwin)
+- **Status**: PASS
+- Command: `LLMUSAGE_INSTALL_DIR=/tmp/llmusage-install-test sh install.sh`
+- Verified:
+  - Latest release tag resolved via GitHub API
+  - Correct tarball selected: `llmusage-v0.1.2-aarch64-apple-darwin.tar.gz`
+  - `sha256sums.txt` downloaded, expected hash located by filename
+  - Actual hash matched expected
+  - Binary extracted to install dir
+  - `/tmp/llmusage-install-test/llmusage --version` returned `llmusage 0.1.2`
+  - PATH warning was emitted because the temp dir was not in `PATH`
+
+## Platform Coverage — To Verify Manually
+
+The following platforms are supported by the script but have not yet been exercised end-to-end. The mapping logic and tarball URLs are covered by the code, but a physical or container install run is still recommended before treating these as verified.
+
+- `x86_64-unknown-linux-gnu` (glibc: Debian/Ubuntu, Fedora)
+- `x86_64-unknown-linux-musl` (Alpine)
+- `aarch64-unknown-linux-gnu` (ARM64 Linux: Raspberry Pi OS 64-bit, AWS Graviton)
+- `x86_64-apple-darwin` (Intel macOS)
+
+## Failure Modes — Expected Behavior
+
+### Missing downloader
+- If neither `curl` nor `wget` is available, the script exits with a clear error.
+
+### Missing hasher
+- If neither `sha256sum` nor `shasum` is available, the script exits with a clear error.
+
+### Unsupported OS
+- Any `uname -s` outside `Linux` or `Darwin` exits with a message recommending `cargo install llmusage` after installing a C toolchain.
+
+### Unsupported arch
+- Any `uname -m` outside `x86_64`, `amd64`, `aarch64`, or `arm64` exits with an "unsupported architecture" error.
+
+### Checksum mismatch
+- Exits with an error printing both the expected and actual hashes. The binary is not installed.
+
+### Permission denied on install
+- Exits with a hint to rerun with `sudo sh` or set `LLMUSAGE_INSTALL_DIR` to a user-writable directory.
+
+## Validation Notes
+
+- The installer does not touch the user's `PATH`. It prints a warning with the exact shell rc line to append. This is intentional per the task decision.
+- The installer is served from `raw.githubusercontent.com/openrijal/llmusage/main/install.sh`, so changes go live on merge to `main` without needing a release cut.

--- a/README.md
+++ b/README.md
@@ -33,15 +33,15 @@ llmusage collects usage data from multiple AI sources — API dashboards, local 
 
 ## Installation
 
-### Prerequisites
+### Install script (recommended on Linux and macOS)
 
-You need the [Rust toolchain](https://rustup.rs/) installed for source-based installation methods. No other system dependencies are required — SQLite is bundled.
-
-### From crates.io (recommended)
+One-liner that downloads the right prebuilt binary for your platform and drops it into a bin directory. No Rust toolchain, no C compiler, no build step:
 
 ```bash
-cargo install llmusage
+curl -LsSf https://raw.githubusercontent.com/openrijal/llmusage/main/install.sh | sh
 ```
+
+The script installs to `/usr/local/bin` when run as root, otherwise to `$HOME/.local/bin`. Override with `LLMUSAGE_INSTALL_DIR=/your/path`, or pin a version with `LLMUSAGE_VERSION=v0.1.2`. Supports macOS (Intel & Apple Silicon) and Linux (x86_64 glibc/musl, aarch64).
 
 ### From Homebrew (macOS)
 
@@ -49,11 +49,19 @@ cargo install llmusage
 brew install openrijal/tap/llmusage
 ```
 
+### From crates.io
+
+```bash
+cargo install llmusage
+```
+
+This route compiles from source and needs the [Rust toolchain](https://rustup.rs/) plus a working C compiler (`build-essential` on Debian/Ubuntu, `base-devel` on Arch, `build-base` on Alpine, Xcode Command Line Tools on macOS) because `rusqlite` bundles SQLite. If you don't want to install a C toolchain, use the install script above or Homebrew instead.
+
 ### Pre-built binaries
 
-Download the latest binary for your platform from [GitHub Releases](https://github.com/openrijal/llmusage/releases).
+Download the tarball for your platform directly from [GitHub Releases](https://github.com/openrijal/llmusage/releases).
 
-Available for: macOS (Intel & Apple Silicon), Linux (x86_64, ARM64).
+Available for: macOS (Intel & Apple Silicon), Linux (x86_64 glibc, x86_64 musl, aarch64).
 
 ### Build from source
 
@@ -202,6 +210,9 @@ TOML config at platform-specific location:
 ## Uninstall
 
 ```bash
+# If installed via the install script (default location)
+rm "$HOME/.local/bin/llmusage"   # or /usr/local/bin/llmusage when installed as root
+
 # If installed via cargo
 cargo uninstall llmusage
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,144 @@
+#!/bin/sh
+# llmusage installer — downloads the prebuilt release binary for your
+# platform and drops it into a bin directory. Use this instead of
+# `cargo install llmusage` when you don't have a C toolchain (gcc,
+# build-essential) installed on your machine.
+#
+# Usage:
+#   curl -LsSf https://raw.githubusercontent.com/openrijal/llmusage/main/install.sh | sh
+#
+# Environment variables:
+#   LLMUSAGE_VERSION       Specific version to install (e.g. v0.1.2). Default: latest.
+#   LLMUSAGE_INSTALL_DIR   Install directory. Default: /usr/local/bin if root, else $HOME/.local/bin.
+
+set -eu
+
+REPO="openrijal/llmusage"
+BIN_NAME="llmusage"
+
+err() { printf 'error: %s\n' "$*" >&2; exit 1; }
+info() { printf '%s\n' "$*"; }
+
+command -v uname >/dev/null 2>&1 || err "missing required command: uname"
+command -v tar >/dev/null 2>&1 || err "missing required command: tar"
+command -v mkdir >/dev/null 2>&1 || err "missing required command: mkdir"
+
+if command -v curl >/dev/null 2>&1; then
+    http_get() { curl -fsSL "$1"; }
+elif command -v wget >/dev/null 2>&1; then
+    http_get() { wget -qO- "$1"; }
+else
+    err "need either curl or wget to download files"
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+    sha_cmd() { sha256sum "$1" | awk '{print $1}'; }
+elif command -v shasum >/dev/null 2>&1; then
+    sha_cmd() { shasum -a 256 "$1" | awk '{print $1}'; }
+else
+    err "need either sha256sum or shasum to verify downloads"
+fi
+
+OS=$(uname -s)
+ARCH=$(uname -m)
+
+case "$OS" in
+    Linux)
+        case "$ARCH" in
+            x86_64|amd64)
+                if (ldd --version 2>&1 | grep -qi musl) || [ -f /etc/alpine-release ]; then
+                    TARGET="x86_64-unknown-linux-musl"
+                else
+                    TARGET="x86_64-unknown-linux-gnu"
+                fi
+                ;;
+            aarch64|arm64)
+                TARGET="aarch64-unknown-linux-gnu"
+                ;;
+            *)
+                err "unsupported Linux architecture: $ARCH"
+                ;;
+        esac
+        ;;
+    Darwin)
+        case "$ARCH" in
+            x86_64)
+                TARGET="x86_64-apple-darwin"
+                ;;
+            arm64|aarch64)
+                TARGET="aarch64-apple-darwin"
+                ;;
+            *)
+                err "unsupported macOS architecture: $ARCH"
+                ;;
+        esac
+        ;;
+    *)
+        err "unsupported OS: $OS (install a C toolchain and try 'cargo install llmusage' instead)"
+        ;;
+esac
+
+VERSION="${LLMUSAGE_VERSION:-}"
+if [ -z "$VERSION" ]; then
+    info "Resolving latest release..."
+    VERSION=$(http_get "https://api.github.com/repos/$REPO/releases/latest" 2>/dev/null \
+        | sed -n 's/.*"tag_name" *: *"\([^"]*\)".*/\1/p' | head -n1)
+    [ -n "$VERSION" ] || err "could not resolve latest release (set LLMUSAGE_VERSION=vX.Y.Z)"
+fi
+
+if [ -n "${LLMUSAGE_INSTALL_DIR:-}" ]; then
+    INSTALL_DIR="$LLMUSAGE_INSTALL_DIR"
+elif [ "$(id -u)" = "0" ]; then
+    INSTALL_DIR="/usr/local/bin"
+else
+    INSTALL_DIR="$HOME/.local/bin"
+fi
+
+TARBALL="${BIN_NAME}-${VERSION}-${TARGET}.tar.gz"
+BASE_URL="https://github.com/$REPO/releases/download/${VERSION}"
+TMP=$(mktemp -d 2>/dev/null || mktemp -d -t llmusage-install)
+trap 'rm -rf "$TMP"' EXIT INT TERM
+
+info "Downloading $TARBALL..."
+http_get "$BASE_URL/$TARBALL" > "$TMP/$TARBALL" \
+    || err "failed to download $BASE_URL/$TARBALL"
+[ -s "$TMP/$TARBALL" ] || err "downloaded tarball is empty ($BASE_URL/$TARBALL)"
+
+info "Verifying checksum..."
+http_get "$BASE_URL/sha256sums.txt" > "$TMP/sha256sums.txt" \
+    || err "failed to download checksums"
+EXPECTED=$(awk -v f="$TARBALL" '$2 == f {print $1}' "$TMP/sha256sums.txt")
+[ -n "$EXPECTED" ] || err "no checksum entry for $TARBALL in sha256sums.txt"
+ACTUAL=$(sha_cmd "$TMP/$TARBALL")
+[ "$EXPECTED" = "$ACTUAL" ] || err "checksum mismatch for $TARBALL
+  expected: $EXPECTED
+  actual:   $ACTUAL"
+
+info "Extracting..."
+tar -xzf "$TMP/$TARBALL" -C "$TMP"
+[ -f "$TMP/$BIN_NAME" ] || err "binary '$BIN_NAME' not found inside tarball"
+
+mkdir -p "$INSTALL_DIR" 2>/dev/null || err "cannot create $INSTALL_DIR"
+DEST="$INSTALL_DIR/$BIN_NAME"
+if ! mv -f "$TMP/$BIN_NAME" "$DEST" 2>/dev/null; then
+    err "cannot write to $DEST (try 'sudo sh' or set LLMUSAGE_INSTALL_DIR=\$HOME/bin)"
+fi
+chmod +x "$DEST"
+
+info ""
+info "Installed $BIN_NAME $VERSION to $DEST"
+
+case ":$PATH:" in
+    *":$INSTALL_DIR:"*)
+        info "Run '$BIN_NAME --help' to get started."
+        ;;
+    *)
+        info ""
+        info "Warning: $INSTALL_DIR is not in your PATH."
+        info "Add it by appending this line to your shell rc (~/.bashrc, ~/.zshrc, etc.):"
+        info ""
+        info "    export PATH=\"\$PATH:$INSTALL_DIR\""
+        info ""
+        info "Or invoke it with the full path: $DEST"
+        ;;
+esac


### PR DESCRIPTION
## Summary

A developer reported that `cargo install llmusage` failed on a fresh Linux machine with a `cc` error while compiling `rusqlite`'s bundled SQLite. The dependency set hasn't changed between v0.1.1 and v0.1.2 — only the version number — but `cargo install` re-resolves transitive deps on every run and requires a C toolchain for anything with native dependencies.

This PR adds `install.sh`, a self-contained POSIX shell installer that downloads the prebuilt release binary for the user's platform and drops it in a bin directory. No Rust, no C compiler, no compile step.

Usage:

```bash
curl -LsSf https://raw.githubusercontent.com/openrijal/llmusage/main/install.sh | sh
```

### What it handles

- OS detection: Linux, macOS
- Arch detection: x86_64 / amd64, aarch64 / arm64
- Linux libc detection (glibc vs musl) via `ldd --version` and `/etc/alpine-release`
- Version resolution via GitHub API (`releases/latest`), with `LLMUSAGE_VERSION=vX.Y.Z` override
- Install dir: `/usr/local/bin` when root, `$HOME/.local/bin` otherwise, overridable via `LLMUSAGE_INSTALL_DIR`
- sha256 verification against `sha256sums.txt` (mandatory, not optional)
- Works with either `curl` or `wget`, and either `sha256sum` or `shasum`
- PATH warning if the install dir isn't on PATH

### Specs

Following the existing `.specs/` pattern:

- `.specs/tasks/install-script/task_170426_install_script.md`
- `.specs/implementation/install-script/impl_170426_install_script.md`
- `.specs/validation/install-script/validate_170426_install_script.md`
- `.specs/prd.md` distribution section updated

### Test plan

- [x] `shellcheck install.sh` — no warnings
- [x] `bash -n install.sh` — syntax clean
- [x] End-to-end run on macOS arm64: downloaded v0.1.2 tarball, verified checksum, extracted, `llmusage --version` returns `llmusage 0.1.2`
- [ ] Verify on Linux x86_64 glibc
- [ ] Verify on Linux x86_64 musl (Alpine)
- [ ] Verify on Linux aarch64

README is updated to lead with the install script, call out the C toolchain requirement for `cargo install`, and note the new uninstall path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)