### PR TITLE
Hint when Cursor has conversations but zero tokens

### DIFF
--- a/src/collectors/cursor.rs
+++ b/src/collectors/cursor.rs
@@ -99,14 +99,15 @@ impl Collector for CursorCollector {
         }
 
         let model_names = load_model_names(&conn)?;
+        // Select every bubble, not just those with nonzero tokens. We need the
+        // full count so we can surface a diagnostic hint when Cursor persisted
+        // conversations but recorded zero tokens (typically: free-plan
+        // requests blocked by error 51 "Named models unavailable", aborted
+        // sessions, or in-flight requests).
         let mut stmt = conn.prepare(
             "SELECT key, CAST(value AS TEXT)
              FROM cursorDiskKV
-             WHERE key LIKE 'bubbleId:%'
-               AND (
-                 COALESCE(json_extract(CAST(value AS TEXT), '$.tokenCount.inputTokens'), 0) > 0
-                 OR COALESCE(json_extract(CAST(value AS TEXT), '$.tokenCount.outputTokens'), 0) > 0
-               )",
+             WHERE key LIKE 'bubbleId:%'",
         )?;
 
         let rows = stmt.query_map([], |row| {
@@ -116,8 +117,10 @@ impl Collector for CursorCollector {
         })?;
 
         let mut records = Vec::new();
+        let mut total_bubbles: usize = 0;
         for row in rows {
             let (key, payload) = row?;
+            total_bubbles += 1;
             let Some(payload) = payload else {
                 continue;
             };
@@ -127,6 +130,17 @@ impl Collector for CursorCollector {
         }
 
         let _ = std::fs::remove_file(temp_db);
+
+        if records.is_empty() && total_bubbles > 0 {
+            eprintln!(
+                "cursor: found {} conversation(s) on disk but none recorded token usage. \
+                 Likely causes: Cursor free plan blocking named models (error 51), aborted \
+                 or errored requests, or requests still in flight. Switch the Cursor model \
+                 picker to 'Auto' or verify your Cursor plan, then retry after a new chat.",
+                total_bubbles
+            );
+        }
+
         Ok(records)
     }
 }


### PR DESCRIPTION
## Summary

A user ran \`llmusage sync\` and saw \`cursor... ok (0 records)\` with no explanation, even though Cursor was clearly installed and had been used. Diagnosis: his \`state.vscdb\` had 12 \`bubbleId:*\` rows but every single one carried \`tokenCount: {inputTokens: 0, outputTokens: 0}\` because Cursor's server rejected every request with error 51 \"Named models unavailable\" (free plan attempting a named model like \`gpt-5.3-codex-low\`). No tokens were ever spent, so the collector correctly returned zero records — but the user had no way to know that.

This adds a stderr hint for exactly that scenario.

## Behavior

- Drops the SQL-level \`tokens > 0\` filter (minor; we already check in Rust via \`parse_bubble_row\`).
- Tracks how many \`bubbleId:*\` rows existed in the DB.
- If the final record count is 0 but one or more bubbles were found, prints:

  > cursor: found N conversation(s) on disk but none recorded token usage. Likely causes: Cursor free plan blocking named models (error 51), aborted or errored requests, or requests still in flight. Switch the Cursor model picker to 'Auto' or verify your Cursor plan, then retry after a new chat.

- Normal (non-empty) runs and fully-empty (no bubbles at all) runs are unchanged.

## Test plan

- [x] \`cargo build\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] Existing \`cursor\` tests pass (3/3)
- [ ] Exercise on a real Cursor state.vscdb with zero-token bubbles (pending — asked the affected user to rerun)

🤖 Generated with [Claude Code](https://claude.com/claude-code)