### PR TITLE
Automate CHANGELOG.md and release notes with git-cliff

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,14 @@ jobs:
     name: Create Release
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
+      - name: Checkout (full history for git-cliff)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
@@ -103,10 +110,48 @@ jobs:
           cd artifacts
           sha256sum *.tar.gz > sha256sums.txt
 
+      - name: Generate release notes with git-cliff
+        uses: orhun/git-cliff-action@v4
+        id: cliff-release-notes
+        with:
+          config: cliff.toml
+          args: --latest --strip all
+        env:
+          OUTPUT: RELEASE_NOTES.md
+
+      - name: Regenerate full CHANGELOG.md with git-cliff
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          args: --output CHANGELOG.md
+
+      - name: Commit CHANGELOG.md back to main
+        run: |
+          # If nothing changed vs. the current tree, there's nothing to commit.
+          if git diff --quiet -- CHANGELOG.md; then
+            echo "CHANGELOG.md unchanged; skipping commit"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Switch onto main (we checked out the tag), keeping the regenerated
+          # CHANGELOG.md in the working tree so the commit lands on main.
+          git fetch origin main
+          git stash push -- CHANGELOG.md
+          git checkout -B main origin/main
+          git stash pop
+          if git diff --quiet -- CHANGELOG.md; then
+            echo "CHANGELOG.md already current on main"
+            exit 0
+          fi
+          git add CHANGELOG.md
+          git commit -m "Update CHANGELOG for ${GITHUB_REF_NAME}"
+          git push origin main
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          generate_release_notes: true
+          body_path: RELEASE_NOTES.md
           files: |
             artifacts/*.tar.gz
             artifacts/sha256sums.txt

--- a/.specs/implementation/changelog-automation/impl_170426_changelog_automation.md
+++ b/.specs/implementation/changelog-automation/impl_170426_changelog_automation.md
@@ -1,0 +1,51 @@
+# Implementation Details - Changelog Automation
+
+## Summary
+
+Adds `cliff.toml`, seeds `CHANGELOG.md` with the full history for `v0.1.0` through `v0.1.2`, and extends `.github/workflows/release.yml` so that every tag push (matching `v*`) regenerates both the GitHub release body and `CHANGELOG.md` at the repo root.
+
+## File Layout
+
+- `cliff.toml` (new) — git-cliff configuration.
+- `CHANGELOG.md` (new) — Keep a Changelog format.
+- `.github/workflows/release.yml` — release job extended to invoke git-cliff and commit the changelog.
+- `.specs/prd.md` — distribution section unchanged; release process notes updated informally via this spec.
+
+## cliff.toml
+
+- `conventional_commits = false` — commit messages are not required to match the Conventional Commits spec.
+- Regex-based `commit_parsers` matching the existing history:
+  - `^(Add|Introduce|Implement|Support) ` → **Added**
+  - `^Fix` → **Fixed**
+  - `^(Remove|Drop|Delete) ` → **Removed**
+  - `^Deprecate ` → **Deprecated**
+  - Catch-all `.*` → **Changed**
+- `skip = true` rules for version bumps, `cargo fmt` commits, merge commits, previous `Update CHANGELOG` commits, and `chore(release)` style tags so the file only contains user-facing lines.
+- `tag_pattern = "v[0-9]+\\.[0-9]+\\.[0-9]+$"` — changelog sections are driven exclusively by semver tags.
+- Keep-a-Changelog style header + per-release body template.
+
+## Release Workflow
+
+`release.yml::release` job additions:
+
+1. `actions/checkout@v4` with `fetch-depth: 0` so git-cliff sees the full tag history.
+2. `orhun/git-cliff-action@v4` call #1 (`--latest --strip all`) → writes per-release notes to `RELEASE_NOTES.md`.
+3. `orhun/git-cliff-action@v4` call #2 (`--output CHANGELOG.md`) → regenerates the full changelog.
+4. A bash step that:
+   - Early-exits if `CHANGELOG.md` is unchanged against the tag's tree.
+   - Stashes the regenerated `CHANGELOG.md`, switches onto `main`, pops the stash, and commits `"Update CHANGELOG for <tag>"` attributed to `github-actions[bot]`.
+   - Pushes the commit to `origin/main`.
+5. `softprops/action-gh-release@v2` now uses `body_path: RELEASE_NOTES.md` instead of `generate_release_notes: true`, so the release description is the curated git-cliff output rather than GitHub's auto-generated list of PRs.
+
+The job grants `permissions.contents: write` explicitly so the `main`-branch push succeeds without relying on inherited defaults.
+
+## Housekeeping
+
+- The generated `Update CHANGELOG for v…` commits are themselves `skip = true` in `cliff.toml` so they don't recurse into future changelog sections.
+- `cargo fmt` and `Bump version` commits are likewise skipped to keep the changelog focused on user-visible changes.
+
+## Out of Scope
+
+- Automating the `Cargo.toml` version bump (release-please territory).
+- Backporting commit messages to conform to Conventional Commits.
+- Emitting a PR for changelog updates instead of a direct push (can be revisited if `main` becomes protected).

--- a/.specs/tasks/changelog-automation/task_170426_changelog_automation.md
+++ b/.specs/tasks/changelog-automation/task_170426_changelog_automation.md
@@ -1,0 +1,24 @@
+# Task Record - Changelog Automation
+
+## Objective
+
+Ship a maintained `CHANGELOG.md` at the repo root, and automate both its upkeep and the GitHub release notes so every tagged release produces a consistent, user-facing changelog without manual writing.
+
+## Scope
+
+- [x] Add `cliff.toml` configured to the project's existing commit style
+- [x] Backfill `CHANGELOG.md` covering `v0.1.0`, `v0.1.1`, `v0.1.2`
+- [x] Hook `git-cliff` into `.github/workflows/release.yml` to:
+  - generate the per-release notes used as the GitHub release body
+  - regenerate the full `CHANGELOG.md` and commit it back to `main`
+- [x] Replace `generate_release_notes: true` on the release action with `body_path: RELEASE_NOTES.md`
+- [x] Grant the release job `contents: write` so it can commit to `main`
+- [x] Document the changelog in the README installation/contribution area (optional — skipped for v1)
+
+## Decisions
+
+- **git-cliff over release-please.** release-please is more automated but requires the project to adopt strict Conventional Commit prefixes (`feat:`, `fix:`, …). The project's history uses imperative verbs (`Add …`, `Fix …`, `Bump …`), and switching style is a bigger lift than this feature warrants. git-cliff supports regex parsers keyed to the existing style.
+- **Keep a Changelog style** for the CHANGELOG.md format — familiar, widely recognized, simple to read.
+- **Auto-commit CHANGELOG.md back to `main`** after the tag push. The alternative is requiring the maintainer to run `git-cliff` locally before tagging; that is error-prone and creates a "forgot to update the changelog" failure mode.
+- **Housekeeping commits are skipped** (version bumps, `cargo fmt` only, merge commits, previous `Update CHANGELOG` commits) so the changelog shows only user-facing changes.
+- **Unreleased section stays** at the top of CHANGELOG.md between releases so in-flight changes are visible on `main` without waiting for a tag.

--- a/.specs/validation/changelog-automation/validate_170426_changelog_automation.md
+++ b/.specs/validation/changelog-automation/validate_170426_changelog_automation.md
@@ -1,0 +1,34 @@
+# Validation Record - Changelog Automation
+
+## Local Verification
+
+### git-cliff --config cliff.toml --output CHANGELOG.md
+- **Status**: PASS
+- Generates a Keep-a-Changelog style file with sections for `Unreleased`, `0.1.2`, `0.1.1`, `0.1.0`.
+- Each release is grouped into `Added`, `Changed`, `Fixed`, `Removed` as appropriate for that release.
+- Housekeeping commits (`Bump version …`, `Apply cargo fmt`, merge commits) are excluded.
+
+### git-cliff --config cliff.toml --latest --strip all
+- **Status**: PASS
+- Produces only the most recent release section with no header, suitable for use as the GitHub release body.
+
+## Workflow Steps — To Verify on Next Tag
+
+The release workflow has not yet been exercised end-to-end because that requires cutting a new tag. The following should be validated on the next release (`v0.1.3` or later):
+
+- `Create Release` job uses `RELEASE_NOTES.md` (produced by git-cliff) as the release body, not the default auto-generated GitHub notes.
+- `Commit CHANGELOG.md back to main` step either commits a new `Update CHANGELOG for vX.Y.Z` commit or exits cleanly with "CHANGELOG.md unchanged".
+- The new commit on `main` is attributed to `github-actions[bot]` and does not break branch-protection rules.
+- No recursion: the `Update CHANGELOG for …` commit itself is skipped by `cliff.toml` and therefore does not appear in the next release's changelog.
+
+## Backfill Correctness
+
+- `v0.1.0` section captures the initial CLI, collectors, and release tooling.
+- `v0.1.1` section captures the homepage/email/badge updates.
+- `v0.1.2` section captures the Gemini CLI JSONL collector, Cursor strict-mode support, the four collector bugfixes, and the release-pipeline lockfile fix.
+- `Unreleased` currently captures the install script and workflow-permission changes, consistent with the commit history on `main`.
+
+## Validation Notes
+
+- `generate_release_notes: true` has been removed from the release action to avoid duplicate release notes; git-cliff is now the single source of truth.
+- The stash + checkout dance in the commit step exists because the workflow checks out the tag, not `main`. Switching branches while keeping the regenerated file in the working tree is the simplest way to land the commit on `main`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,81 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [Unreleased]
+
+
+### Added
+
+- Add specs for install script feature (d7b0916)
+- Add curl | sh installer script (4881596)
+
+### Changed
+
+- gemini fix specs (66fb0c7)
+- Allow manual trigger for Security Audit workflow (e016bcb)
+- Grant checks:write to Security Audit workflow (67550e0)
+## [0.1.2] - 2026-04-17
+
+
+### Added
+
+- Add strict-mode IDE support for Cursor (89c8172)
+- Add Gemini CLI JSONL log support (8fab86f)
+
+### Changed
+
+- Clarify Cursor Linux path support (44409a0)
+- Expand .gitignore with common artifacts (78ebd13)
+
+### Fixed
+
+- Fix release publish step to tolerate cargo package's lockfile regen (d18d21a)
+- Fix four collector and export bugs (5af89d0)
+## [0.1.1] - 2026-04-16
+
+
+### Changed
+
+- Point homepage to niteshrijal.com, keep repository as GitHub URL (ad4e3b3)
+- Update contact email to namaste@niteshrijal.com (b42880e)
+- Change downloads badge label to distinguish from version badge (23d7442)
+## [0.1.0] - 2026-04-16
+
+
+### Added
+
+- Add weekly security audit workflow with cargo-audit (2693471)
+- Add Homebrew formula auto-update workflow on release (c615611)
+- Add automated crates.io publish workflow on release (96fe1c1)
+- Add release workflow to build cross-platform binaries on tag push (2d24f4c)
+- Add CI workflow for build, lint, and test checks on PRs (7ff10a6)
+- Add CONTRIBUTING.md with development and contribution guide (7a2f05a)
+- Add authors, readme, and homepage to Cargo.toml for crates.io publishing (d7d6a7f)
+- Add MIT LICENSE file (1a9027e)
+- Add screenshots directory for README usage examples (ab3dde5)
+- Add provider-grouped table display with per-model breakdown (00ab012)
+- Add comprehensive README with usage, commands, and configuration (e003ca6)
+- Add AGENTS.md with project overview, conventions, and pitfalls (f63947b)
+- Add project spec: PRD, task list, implementation details, validation (ad18eaa)
+- Add llmusage CLI - token usage tracker across AI providers (74d4015)
+
+### Changed
+
+- Consolidate publish and homebrew workflows into release pipeline (469b38f)
+- Switch reqwest from OpenSSL to rustls-tls for portable cross-compilation (1cd1513)
+- Improve README with badges, expanded install methods, and uninstall section (79444cb)
+- Update README with screenshots section and daily usage screenshot (403d4ba)
+- Rename .spec/ to .specs/ for consistency (75a4fd4)
+- Move spec files into branch-named subfolders (4700554)
+- first commit (a347298)
+- first commit (5462af1)
+
+### Fixed
+
+- Fix formatting to pass cargo fmt --check in CI (cfc1cf6)
+- Fix table alignment, zero-token filter, and --all JSON consistency (7e03a93)
+- Fix dedup NULL session_id, --until date filtering, and Ollama default host (d101308)
+

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,70 @@
+# git-cliff configuration for llmusage
+# See https://git-cliff.org/docs/configuration
+
+[changelog]
+# Keep a Changelog style header. Emitted once at the top of CHANGELOG.md.
+header = """
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+"""
+
+# Per-release section template. Rendered once per tag.
+body = """
+{% if version -%}
+## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else -%}
+## [Unreleased]
+{% endif %}
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}
+- {{ commit.message | split(pat="\\n") | first | trim }}{% if commit.id %} ({{ commit.id | truncate(length=7, end="") }}){% endif %}
+{%- endfor %}
+{% endfor %}
+"""
+
+footer = ""
+trim = true
+# Keep only commits that matched a group.
+postprocessors = []
+
+[git]
+conventional_commits = false
+filter_unconventional = false
+split_commits = false
+
+# Commit classification. The first matching regex wins. Commits with
+# `skip = true` or no matching rule are omitted from the changelog.
+commit_parsers = [
+    # Release housekeeping — never shown in the changelog.
+    { message = "^Bump version", skip = true },
+    { message = "^Apply cargo fmt", skip = true },
+    { message = "^Merge pull request", skip = true },
+    { message = "^Merge branch", skip = true },
+    { message = "^Release ", skip = true },
+    { message = "^chore\\(release\\)", skip = true },
+    { message = "^Update CHANGELOG", skip = true },
+
+    # Meaningful changes — mapped to Keep-a-Changelog sections.
+    { message = "^(Add|Introduce|Implement|Support) ", group = "Added" },
+    { message = "^Fix", group = "Fixed" },
+    { message = "^(Remove|Drop|Delete) ", group = "Removed" },
+    { message = "^Deprecate ", group = "Deprecated" },
+    # Catch-all for wording like Change/Update/Refactor/Bump (non-version)/Grant/Allow/Point/Expand/Clarify/Switch/Consolidate.
+    { message = ".*", group = "Changed" },
+]
+
+# Drop commits that still end up in no group (defensive; the catch-all
+# above should cover everything except `skip = true` rules).
+filter_commits = true
+
+# Tag matching. Only release tags drive changelog sections.
+tag_pattern = "v[0-9]+\\.[0-9]+\\.[0-9]+$"
+
+# Sort newest release first.
+topo_order = false
+sort_commits = "newest"


### PR DESCRIPTION
## Summary

Adds \`cliff.toml\`, backfills \`CHANGELOG.md\` for v0.1.0-v0.1.2, and extends the release workflow so every tag push:

1. Regenerates \`CHANGELOG.md\` from git history and commits it back to \`main\`.
2. Produces per-release notes (via \`git-cliff --latest --strip all\`) and uses them as the GitHub release body, replacing the default auto-generated PR list.

### Why git-cliff (not release-please)

The project's history uses imperative commit verbs (\`Add …\`, \`Fix …\`, \`Bump …\`) rather than Conventional Commits prefixes. git-cliff's regex parsers work with that style directly; release-please would require changing the commit convention first.

### Specs

- \`.specs/tasks/changelog-automation/task_170426_changelog_automation.md\`
- \`.specs/implementation/changelog-automation/impl_170426_changelog_automation.md\`
- \`.specs/validation/changelog-automation/validate_170426_changelog_automation.md\`

### Test plan

- [x] \`git-cliff --config cliff.toml --output CHANGELOG.md\` produces a Keep-a-Changelog style file with the right sections
- [x] \`git-cliff --config cliff.toml --latest --strip all\` produces the single-release body used for the release
- [ ] End-to-end verification on the next real tag (\`v0.1.3\` or later):
  - GitHub release body comes from git-cliff, not auto-notes
  - \`Update CHANGELOG for vX.Y.Z\` commit lands on \`main\`
  - The update-commit itself doesn't show up in the next release's changelog (it's skipped by config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)