### PR TITLE
Make release CHANGELOG auto-commit non-fatal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,11 @@ jobs:
           args: --output CHANGELOG.md
 
       - name: Commit CHANGELOG.md back to main
+        # Non-fatal: if branch protection rejects the push (rule requires PR),
+        # let the release continue. The maintainer can update CHANGELOG.md
+        # manually after the release, or we'll switch to a PR-based update
+        # flow in a follow-up.
+        continue-on-error: true
         run: |
           # If nothing changed vs. the current tree, there's nothing to commit.
           if git diff --quiet -- CHANGELOG.md; then


### PR DESCRIPTION
Branch protection on main blocks direct pushes from GitHub Actions (rule requires PR). That was hard-failing the release workflow's CHANGELOG update step and cascading to skip the GitHub release, crates.io publish, and Homebrew update. Setting continue-on-error so the release ships even when the CHANGELOG backport is blocked. Follow-up: switch to a PR-based update flow or PAT with bypass.