### PR TITLE
Fix data correctness: CSV escaping, pricing cache, daily totals

### DIFF
--- a/.specs/implementation/data-correctness/impl_170426_data_correctness.md
+++ b/.specs/implementation/data-correctness/impl_170426_data_correctness.md
@@ -1,0 +1,73 @@
+# Implementation Details - Data Correctness
+
+## Summary
+
+Two files: `src/display.rs` (CSV escape + daily-totals recompute) and `src/costs.rs` (pricing cache). ~174 insertions / ~19 deletions. No dependency changes.
+
+## `src/display.rs`
+
+### CSV escaping — #31
+
+```rust
+fn csv_escape(field: &str) -> String {
+    let needs_quoting = field
+        .bytes()
+        .any(|b| matches!(b, b',' | b'"' | b'\n' | b'\r'));
+    if !needs_quoting { return field.to_string(); }
+    let escaped = field.replace('"', "\"\"");
+    format!("\"{}\"", escaped)
+}
+```
+
+`to_csv` now wraps `r.provider`, `r.model`, and `r.recorded_at` in `csv_escape`. Numeric columns (`input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_write_tokens`, `cost_usd`) are emitted via `{}` unchanged — they can't contain CSV-hostile bytes.
+
+### `filter_daily_rows` totals & ordering — #48
+
+```rust
+// Preserve first-seen ordering of model names.
+let mut seen = HashSet::new();
+let mut models: Vec<String> = Vec::new();
+for entry in &filtered {
+    if seen.insert(entry.model.clone()) {
+        models.push(entry.model.clone());
+    }
+}
+
+// Recompute totals from visible entries.
+let total_input:  i64 = filtered.iter().map(|e| e.input_tokens).sum();
+let total_output: i64 = filtered.iter().map(|e| e.output_tokens).sum();
+let total_cost:   f64 = filtered.iter().map(|e| e.cost).sum();
+```
+
+The `show_all: true` branch still early-returns `rows.to_vec()`, so unfiltered totals are untouched.
+
+## `src/costs.rs`
+
+### Process-lifetime pricing cache — #32
+
+```rust
+use std::sync::OnceLock;
+
+static PRICING_CACHE: OnceLock<Option<HashMap<String, LiteLLMEntry>>> = OnceLock::new();
+
+fn load_cached_pricing() -> Option<&'static HashMap<String, LiteLLMEntry>> {
+    PRICING_CACHE
+        .get_or_init(|| {
+            let path = cache_path();
+            let content = std::fs::read_to_string(path).ok()?;
+            serde_json::from_str(&content).ok()
+        })
+        .as_ref()
+}
+```
+
+Return type changed from `Option<HashMap<...>>` to `Option<&'static HashMap<...>>`.
+
+### Caller updates
+
+- `get_model_pricing` now iterates with `.iter()` and clones `model_key` per surviving entry. Previous `into_iter()` consumed an owned map; no longer possible with a borrowed static.
+- `calculate_cost` uses `.get(model)` and `.get(&prefixed)` on the reference — source unchanged (already compatible with `&HashMap`).
+
+## No Public API Changes
+
+`to_csv`, `filter_daily_rows`, `calculate_cost`, and `get_model_pricing` keep their existing signatures. The internal `load_cached_pricing` is module-private.

--- a/.specs/tasks/data-correctness/task_170426_data_correctness.md
+++ b/.specs/tasks/data-correctness/task_170426_data_correctness.md
@@ -1,0 +1,32 @@
+# Task Record - Data Correctness: CSV Escaping, Pricing Cache, Daily Totals
+
+## Objective
+
+Close three correctness/performance issues that share a "wrong data out" flavor:
+
+- **#31** — `display::to_csv` manually concatenates fields with commas; no RFC 4180 quoting. Provider or model names containing commas/quotes/newlines produce malformed CSV that downstream parsers (Excel, pandas) silently misinterpret.
+- **#32** — `costs::load_cached_pricing` reads and parses the ~2MB LiteLLM JSON on every call. `calculate_cost` is invoked once per usage record, so `llmusage sync` on a large Claude Code history re-parses the file thousands of times. This is the dominant sync bottleneck.
+- **#48** — `display::filter_daily_rows` preserves original `total_input`/`total_output`/`total_cost` after filtering zero-token entries, so the totals row can disagree with the sum of visible entries. The `models` list is also rebuilt via `HashSet`, which randomizes order and breaks JSON-export determinism.
+
+Bundle them: all three are in the display + costs modules and touch the "what the user sees / exports" contract. Fixing them together keeps the reviewer context coherent.
+
+## Scope
+
+- [x] **#31** — introduce `csv_escape(&str) -> String` that quotes fields containing `,`, `"`, `\n`, or `\r`, and doubles embedded quotes. Apply it to `provider`, `model`, `recorded_at`. Numeric columns stay unquoted.
+- [x] **#32** — cache the parsed `HashMap<String, LiteLLMEntry>` in a `OnceLock`. `load_cached_pricing` returns `Option<&'static HashMap<...>>`. Callers updated to work with references.
+- [x] **#48** — recompute `total_input`/`total_output`/`total_cost` from the post-filter entries. Build `models` via a `HashSet`-backed insertion that preserves first-seen order.
+- [x] Unit tests for each fix.
+
+## Decisions
+
+- **Inline CSV escaping over adding the `csv` crate.** Three-column escaping with ~10 lines of code doesn't justify a new dependency. If CSV needs grow (streaming writer, custom delimiters, BOM), revisit.
+- **`OnceLock` over `LazyLock` or `Mutex<Option<...>>`.** `OnceLock` is std, initialized on first use, zero overhead after init, and doesn't require the `lazy_static` or `once_cell` crates. `update_pricing_cache` still writes the file; the next CLI invocation picks it up. In a single CLI invocation both paths aren't typically called, so staleness is a non-issue.
+- **Borrow the static map, don't clone.** `get_model_pricing` now iterates `entries.iter()` and clones only the `model_key` (String) per-entry. Avoids a full `HashMap` clone per call.
+- **Recompute totals, don't change the struct shape.** `DailyRow` already carries totals; recomputing from `filtered` keeps the contract (`totals == sum(model_entries)`) without touching upstream query code.
+- **Preserve first-seen model order.** `HashSet` is fine for dedup; a small hand-rolled "seen set + ordered vec" avoids pulling in `indexmap` for one call site.
+
+## Out of Scope
+
+- Not switching to a streaming CSV writer — `to_csv` builds a `String` and callers write it whole. Not a memory bottleneck at realistic dataset sizes.
+- No invalidation hook on `PRICING_CACHE` after `update_pricing_cache` within the same process — in practice `update_pricing_cache` is its own CLI command and runs in a fresh process.
+- No change to the `--all` code path that forces unfiltered output (early-returns on `show_all`).

--- a/.specs/validation/data-correctness/validate_170426_data_correctness.md
+++ b/.specs/validation/data-correctness/validate_170426_data_correctness.md
@@ -1,0 +1,38 @@
+# Validation Record - Data Correctness
+
+## Automated Checks
+
+- `cargo fmt --all --check` — PASS
+- `cargo build` — PASS
+- `cargo clippy --all-targets -- -D warnings` — PASS (fixed a `clippy::cloned_ref_to_slice_refs` lint in a new test by using `std::slice::from_ref`)
+- `cargo test` — PASS (17 pre-existing + 8 new = 25 tests)
+
+## New Tests (`src/display.rs::csv_and_filter_tests`)
+
+| Test | Asserts |
+|------|---------|
+| `csv_escape_plain_field_not_quoted` | `gpt-4o` → `gpt-4o` (no quoting) |
+| `csv_escape_comma_gets_quoted` | `foo,bar` → `"foo,bar"` |
+| `csv_escape_quotes_are_doubled` | `he said "hi"` → `"he said ""hi"""` |
+| `csv_escape_newline_gets_quoted` | `\n` and `\r\n` both trigger quoting |
+| `to_csv_escapes_tricky_provider_and_model` | full-row integration: `"acme,co","weird""model",...` |
+| `filter_daily_rows_recomputes_totals_from_visible_entries` | `total_input` drops from 100+0 to 100 when zero entry is removed |
+| `filter_daily_rows_preserves_first_seen_model_order` | `[zeta, alpha, zeta]` → `[zeta, alpha]` |
+| `filter_daily_rows_show_all_returns_unchanged` | `show_all=true` short-circuits |
+
+## Manual Smoke — Recommended Post-Merge
+
+- **#31**: inject a record with `model = "weird\"model"` and run `llmusage export --format csv`. Confirm the output round-trips through `python -c "import csv,sys; list(csv.reader(sys.stdin))"`.
+- **#32**: time `llmusage sync` on a large Claude Code history before/after this PR. Expected: several × speedup on sync-heavy runs. Baseline metric not yet captured in CI; user can verify locally.
+- **#48**: on a day with a mix of zero-token and non-zero-token model entries, run `llmusage daily` (no `--all`) and confirm the totals row equals the arithmetic sum of the displayed rows. Also run `llmusage export --format json` twice and diff — model order should be stable.
+
+## Regression Risk
+
+- **`get_model_pricing` per-call allocation profile.** Previously consumed an owned `HashMap`; now clones `model_key` (String) per surviving entry. Net allocations ≈ O(models × 1 String) instead of O(1 HashMap clone). Not a hot path — called from display commands, not sync.
+- **`PRICING_CACHE` staleness if `update_pricing_cache` is called in the same process after `calculate_cost`.** The cache will not refresh. In the current CLI flow, each command is its own process, so this is a non-issue. If a long-running process is ever introduced, a `refresh()` entry point would be needed.
+- **CSV numeric columns still unquoted.** Correct per RFC 4180 (no hostile bytes in `i64` / `f64` Display), but worth noting if a future column stores formatted strings.
+
+## Rollback
+
+- #31 and #48: revert the `src/display.rs` hunks. Independent, no shared state.
+- #32: reverting `src/costs.rs` restores per-call disk reads. `calculate_cost`'s call site is unchanged, so no cross-file revert needed.

--- a/src/costs.rs
+++ b/src/costs.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::OnceLock;
 
 use anyhow::Result;
 use serde::Deserialize;
@@ -52,11 +53,24 @@ pub async fn update_pricing_cache() -> Result<()> {
     Ok(())
 }
 
-/// Load cached pricing data. Returns None if no cache exists.
-fn load_cached_pricing() -> Option<HashMap<String, LiteLLMEntry>> {
-    let path = cache_path();
-    let content = std::fs::read_to_string(path).ok()?;
-    serde_json::from_str(&content).ok()
+/// Process-lifetime cache of the parsed LiteLLM pricing file.
+///
+/// Reading and parsing the ~2MB JSON on every `calculate_cost` call was the
+/// dominant cost during sync (#32). We load at most once per process — the
+/// file only changes when `update_pricing_cache` is invoked, which happens as
+/// a separate CLI command.
+static PRICING_CACHE: OnceLock<Option<HashMap<String, LiteLLMEntry>>> = OnceLock::new();
+
+/// Load cached pricing data. Returns None if no cache file exists or it fails
+/// to parse. Subsequent calls reuse the in-memory result.
+fn load_cached_pricing() -> Option<&'static HashMap<String, LiteLLMEntry>> {
+    PRICING_CACHE
+        .get_or_init(|| {
+            let path = cache_path();
+            let content = std::fs::read_to_string(path).ok()?;
+            serde_json::from_str(&content).ok()
+        })
+        .as_ref()
 }
 
 /// Map LiteLLM provider names to our provider names.
@@ -88,7 +102,7 @@ pub fn get_model_pricing(provider_filter: Option<&str>) -> Vec<ModelPricing> {
     };
 
     let mut models: Vec<ModelPricing> = entries
-        .into_iter()
+        .iter()
         .filter_map(|(model_key, entry)| {
             // Only include chat models with token pricing
             let mode = entry.mode.as_deref().unwrap_or("");
@@ -111,7 +125,7 @@ pub fn get_model_pricing(provider_filter: Option<&str>) -> Vec<ModelPricing> {
             // Convert per-token to per-million-token for display
             Some(ModelPricing {
                 provider: provider.to_string(),
-                model: model_key,
+                model: model_key.clone(),
                 input_per_mtok: input_per_token * 1_000_000.0,
                 output_per_mtok: output_per_token * 1_000_000.0,
                 cache_read_per_mtok: entry.cache_read_input_token_cost.map(|c| c * 1_000_000.0),

--- a/src/display.rs
+++ b/src/display.rs
@@ -180,19 +180,30 @@ pub fn filter_daily_rows(rows: &[DailyRow], show_all: bool) -> Vec<DailyRow> {
                 .filter(|e| e.input_tokens != 0 || e.output_tokens != 0 || e.cost != 0.0)
                 .cloned()
                 .collect();
-            let models: Vec<String> = filtered
-                .iter()
-                .map(|e| e.model.clone())
-                .collect::<std::collections::HashSet<_>>()
-                .into_iter()
-                .collect();
+
+            // Preserve first-seen ordering of model names (HashSet loses order and
+            // breaks JSON export determinism).
+            let mut seen = std::collections::HashSet::new();
+            let mut models: Vec<String> = Vec::new();
+            for entry in &filtered {
+                if seen.insert(entry.model.clone()) {
+                    models.push(entry.model.clone());
+                }
+            }
+
+            // Recompute totals from the visible entries so the table totals row
+            // matches the sum of displayed rows (#48).
+            let total_input: i64 = filtered.iter().map(|e| e.input_tokens).sum();
+            let total_output: i64 = filtered.iter().map(|e| e.output_tokens).sum();
+            let total_cost: f64 = filtered.iter().map(|e| e.cost).sum();
+
             DailyRow {
                 date: r.date.clone(),
                 models,
                 model_entries: filtered,
-                total_input: r.total_input,
-                total_output: r.total_output,
-                total_cost: r.total_cost,
+                total_input,
+                total_output,
+                total_cost,
             }
         })
         .collect()
@@ -473,6 +484,19 @@ pub fn print_models(models: &[ModelPricing]) {
     print_table_colored(&table);
 }
 
+/// RFC 4180 CSV field escaping: quote fields that contain commas, quotes, CR,
+/// or LF; escape embedded quotes by doubling them.
+fn csv_escape(field: &str) -> String {
+    let needs_quoting = field
+        .bytes()
+        .any(|b| matches!(b, b',' | b'"' | b'\n' | b'\r'));
+    if !needs_quoting {
+        return field.to_string();
+    }
+    let escaped = field.replace('"', "\"\"");
+    format!("\"{}\"", escaped)
+}
+
 pub fn to_csv(rows: &[UsageRecord]) -> anyhow::Result<String> {
     let mut out = String::from(
         "provider,model,input_tokens,output_tokens,cache_read,cache_write,cost_usd,recorded_at\n",
@@ -480,14 +504,14 @@ pub fn to_csv(rows: &[UsageRecord]) -> anyhow::Result<String> {
     for r in rows {
         out.push_str(&format!(
             "{},{},{},{},{},{},{},{}\n",
-            r.provider,
-            r.model,
+            csv_escape(&r.provider),
+            csv_escape(&r.model),
             r.input_tokens,
             r.output_tokens,
             r.cache_read_tokens,
             r.cache_write_tokens,
             r.cost_usd.unwrap_or(0.0),
-            r.recorded_at,
+            csv_escape(&r.recorded_at),
         ));
     }
     Ok(out)
@@ -573,4 +597,121 @@ fn strip_date_suffix(s: &str) -> &str {
         }
     }
     s
+}
+
+#[cfg(test)]
+mod csv_and_filter_tests {
+    use super::*;
+    use crate::models::{DailyRow, ModelEntry, UsageRecord};
+
+    fn rec(provider: &str, model: &str, recorded_at: &str) -> UsageRecord {
+        UsageRecord {
+            id: None,
+            provider: provider.to_string(),
+            model: model.to_string(),
+            input_tokens: 10,
+            output_tokens: 20,
+            cache_read_tokens: 0,
+            cache_write_tokens: 0,
+            cost_usd: Some(0.5),
+            session_id: None,
+            recorded_at: recorded_at.to_string(),
+            collected_at: "2026-04-17T00:00:00Z".to_string(),
+            metadata: None,
+        }
+    }
+
+    #[test]
+    fn csv_escape_plain_field_not_quoted() {
+        assert_eq!(csv_escape("gpt-4o"), "gpt-4o");
+    }
+
+    #[test]
+    fn csv_escape_comma_gets_quoted() {
+        assert_eq!(csv_escape("foo,bar"), "\"foo,bar\"");
+    }
+
+    #[test]
+    fn csv_escape_quotes_are_doubled() {
+        assert_eq!(csv_escape("he said \"hi\""), "\"he said \"\"hi\"\"\"");
+    }
+
+    #[test]
+    fn csv_escape_newline_gets_quoted() {
+        assert_eq!(csv_escape("line1\nline2"), "\"line1\nline2\"");
+        assert_eq!(csv_escape("line1\r\nline2"), "\"line1\r\nline2\"");
+    }
+
+    #[test]
+    fn to_csv_escapes_tricky_provider_and_model() {
+        let rows = vec![rec("acme,co", "weird\"model", "2026-04-17T12:00:00Z")];
+        let csv = to_csv(&rows).unwrap();
+        let line = csv.lines().nth(1).unwrap();
+        assert!(line.starts_with("\"acme,co\",\"weird\"\"model\","));
+    }
+
+    fn entry(model: &str, input: i64, output: i64, cost: f64) -> ModelEntry {
+        ModelEntry {
+            provider: "p".to_string(),
+            model: model.to_string(),
+            input_tokens: input,
+            output_tokens: output,
+            cost,
+        }
+    }
+
+    #[test]
+    fn filter_daily_rows_recomputes_totals_from_visible_entries() {
+        let row = DailyRow {
+            date: "2026-04-17".to_string(),
+            models: vec!["a".to_string(), "b".to_string()],
+            model_entries: vec![entry("a", 100, 50, 0.25), entry("b", 0, 0, 0.0)],
+            total_input: 100,
+            total_output: 50,
+            total_cost: 0.25,
+        };
+        let filtered = filter_daily_rows(&[row], false);
+        let out = &filtered[0];
+        assert_eq!(out.model_entries.len(), 1);
+        assert_eq!(out.total_input, 100);
+        assert_eq!(out.total_output, 50);
+        assert!((out.total_cost - 0.25).abs() < 1e-9);
+        assert_eq!(out.models, vec!["a".to_string()]);
+    }
+
+    #[test]
+    fn filter_daily_rows_preserves_first_seen_model_order() {
+        let row = DailyRow {
+            date: "d".to_string(),
+            models: vec![],
+            model_entries: vec![
+                entry("zeta", 1, 1, 0.1),
+                entry("alpha", 2, 2, 0.2),
+                entry("zeta", 3, 3, 0.3),
+            ],
+            total_input: 0,
+            total_output: 0,
+            total_cost: 0.0,
+        };
+        let filtered = filter_daily_rows(&[row], false);
+        assert_eq!(
+            filtered[0].models,
+            vec!["zeta".to_string(), "alpha".to_string()]
+        );
+    }
+
+    #[test]
+    fn filter_daily_rows_show_all_returns_unchanged() {
+        let row = DailyRow {
+            date: "d".to_string(),
+            models: vec!["a".to_string()],
+            model_entries: vec![entry("a", 0, 0, 0.0)],
+            total_input: 999,
+            total_output: 888,
+            total_cost: 7.0,
+        };
+        let filtered = filter_daily_rows(std::slice::from_ref(&row), true);
+        assert_eq!(filtered[0].total_input, 999);
+        assert_eq!(filtered[0].total_output, 888);
+    }
 }


### PR DESCRIPTION
## Summary
- **#31 CSV escaping:** `to_csv` now RFC 4180-escapes `provider`, `model`, and `recorded_at`. Fields with commas, double quotes, CR, or LF are wrapped in double quotes; embedded quotes are doubled. Numeric columns are unchanged.
- **#32 Pricing cache:** `load_cached_pricing` now caches the parsed LiteLLM map in a process-lifetime `OnceLock`. Each CLI invocation reads/parses the ~2MB JSON once instead of once per usage record, removing the dominant sync bottleneck for large Claude Code histories. `update_pricing_cache` still writes the file — a subsequent CLI invocation picks up the new data.
- **#48 Daily totals & ordering:** `filter_daily_rows` recomputes `total_input`/`total_output`/`total_cost` from the entries that actually remain after filtering, so the totals row always matches the visible rows. `models` is built by first-seen order instead of a `HashSet`, making JSON export deterministic.

## Fixes
- Fixes #31
- Fixes #32
- Fixes #48

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo build`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (25 passed; added 8 unit tests: CSV plain/comma/quote/newline escaping, end-to-end `to_csv` with tricky fields, recomputed totals, preserved model order, `show_all` pass-through)

## Notes
- The OnceLock change switches `load_cached_pricing` to return `Option<&'static HashMap<..>>`. `get_model_pricing` was updated to iterate by reference and clone the model key; `calculate_cost` already used `.get(...)` and works on references unchanged.