### PR TITLE
Fix weekly ISO-week crash (SQLite 3.45 lacks %V/%G) and broken-pipe panic

### DIFF
--- a/.specs/implementation/weekly-iso-and-sigpipe/impl_170426_weekly_iso_and_sigpipe.md
+++ b/.specs/implementation/weekly-iso-and-sigpipe/impl_170426_weekly_iso_and_sigpipe.md
@@ -1,0 +1,76 @@
+# Implementation Details - Weekly ISO + SIGPIPE
+
+## Summary
+
+Three files touched: `Cargo.toml` (+ `libc` dep), `src/db/queries.rs` (ISO-week rebucketing), `src/main.rs` (SIGPIPE reset).
+
+## `Cargo.toml`
+
+```toml
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+```
+
+New target-gated dep — not pulled in on Windows builds.
+
+## `src/db/queries.rs`
+
+### `query_weekly`
+
+```rust
+pub fn query_weekly(conn: &Connection, weeks: u32, provider: Option<&str>)
+    -> Result<Vec<DailyRow>>
+{
+    let daily = query_grouped(
+        conn,
+        "DATE(recorded_at)",
+        &format!("-{} days", weeks * 7),
+        provider,
+    )?;
+    Ok(rebucket_daily_by_iso_week(daily))
+}
+```
+
+`DATE(recorded_at)` is portable on every SQLite version.
+
+### `rebucket_daily_by_iso_week`
+
+```rust
+fn rebucket_daily_by_iso_week(daily: Vec<DailyRow>) -> Vec<DailyRow> {
+    // BTreeMap<week_label, BTreeMap<(provider, model), ModelEntry>>
+    // Iterate daily rows; for each, compute ISO week via chrono and merge
+    // each ModelEntry into the (provider, model) accumulator under that week.
+    // Assemble back into DailyRow list, preserving week-order via BTreeMap.
+}
+```
+
+Behavior:
+
+- Group key is `format!("{}-W{:02}", iw.year(), iw.week())`, e.g. `2026-W16`.
+- Across days in the same ISO week, `ModelEntry`s with the same `(provider, model)` merge — no duplicate rows.
+- `DailyRow.total_*` is recomputed from the merged entries.
+- Unparseable dates are skipped defensively (`DATE(recorded_at)` always yields `YYYY-MM-DD` in practice).
+
+## `src/main.rs`
+
+```rust
+#[cfg(unix)]
+fn reset_sigpipe() {
+    unsafe { libc::signal(libc::SIGPIPE, libc::SIG_DFL); }
+}
+
+#[cfg(not(unix))]
+fn reset_sigpipe() {}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    reset_sigpipe();
+    // ... rest unchanged
+}
+```
+
+After this, writing to a closed pipe terminates the process with the conventional signal-death exit status rather than panicking inside `println!`.
+
+## No Public API Changes
+
+`query_weekly` signature unchanged; return shape unchanged (`Vec<DailyRow>` with week labels in the `date` field). `main` unchanged aside from the one pre-call.

--- a/.specs/tasks/weekly-iso-and-sigpipe/task_170426_weekly_iso_and_sigpipe.md
+++ b/.specs/tasks/weekly-iso-and-sigpipe/task_170426_weekly_iso_and_sigpipe.md
@@ -1,0 +1,29 @@
+# Task Record - Fix Weekly Crash + Broken-Pipe Panic
+
+## Objective
+
+Fix two runtime regressions surfaced during local smoke-testing of v0.1.3 + the bug-bundle merges:
+
+1. **`llmusage weekly` crashes** with `Error: Invalid column type Null at index: 0, name: period`. The prior CHANGELOG-era code used `strftime('%Y-W%W', ...)`; PR #78 changed it to `strftime('%G-W%V', ...)`. `%V` and `%G` were added in **SQLite 3.46** (May 2024); `rusqlite = 0.31` bundles **SQLite 3.45**, which silently returns `NULL` for unknown modifiers. Row decoding then fails on the NULL period column.
+
+2. **Broken-pipe panic** when piping output into `head`, e.g. `llmusage export --format csv | head`. Rust's stdlib sets `SIGPIPE` to `SIG_IGN` at startup, so writing to a closed pipe yields `EPIPE`, and `println!` unwraps the error and panics. The expected CLI behavior is silent termination (matching `cat`, `grep`, etc.).
+
+## Scope
+
+- [x] Replace the SQL-side ISO-week grouping with an in-process rebucketing using `chrono::Datelike::iso_week`. Portable on every bundled SQLite version.
+- [x] Add `libc` as a `cfg(unix)` dependency and reset `SIGPIPE` to `SIG_DFL` at the top of `main`.
+- [x] Unit tests for ISO-week bucketing: same-week aggregation, Monday boundary split, year-boundary (`2027-01-01 → 2026-W53`), cross-day model merge.
+- [x] Manual smoke: `llmusage weekly` renders, `llmusage export --format csv | head` exits 0.
+
+## Decisions
+
+- **Compute ISO weeks in Rust, not SQL.** Bumping `rusqlite` to a version that bundles SQLite 3.46+ would work but carries API churn risk across a minor-version jump during a release-prep window. The Rust computation is ~60 lines, uses an already-present `chrono` dep, is test-friendly, and eliminates any future "bundled SQLite is too old" surprise. The small cost is that weekly aggregation now runs in-process instead of server-side — irrelevant at the row counts involved.
+- **Reset `SIGPIPE` to `SIG_DFL` globally at `main` entry.** Alternative: wrap every `println!` in a pattern that handles `EPIPE` cleanly. Rejected — invasive and easy to regress. The signal reset is one line, POSIX-standard behavior, and matches user expectations for a Unix pipeline tool. Windows gets a no-op stub.
+- **Add `libc = "0.2"` under `[target.'cfg(unix)'.dependencies]`.** Avoiding a direct FFI `extern "C"` block keeps the unsafe surface minimal and well-audited.
+- **Earlier spec claim was wrong.** `.specs/tasks/quick-bugs-bundle/task_170426_quick_bugs_bundle.md` asserted SQLite ≥ 3.44 sufficed; that was incorrect (the modifiers land in 3.46). Not amending the historical spec — this task records the correction instead.
+
+## Out of Scope
+
+- No data migration or schema change.
+- Not upgrading `rusqlite`. Considered and deferred.
+- Monthly grouping (`%Y-%m`) is unaffected — `%Y` and `%m` have been in SQLite since forever.

--- a/.specs/validation/weekly-iso-and-sigpipe/validate_170426_weekly_iso_and_sigpipe.md
+++ b/.specs/validation/weekly-iso-and-sigpipe/validate_170426_weekly_iso_and_sigpipe.md
@@ -1,0 +1,47 @@
+# Validation Record - Weekly ISO + SIGPIPE
+
+## Automated Checks
+
+- `cargo fmt --all --check` — PASS
+- `cargo build --release` — PASS
+- `cargo clippy --all-targets -- -D warnings` — PASS
+- `cargo test` — PASS (37 pre-existing + 4 new = 41 tests)
+
+## New Tests (`src/db/queries.rs::iso_week_tests`)
+
+| Test | Asserts |
+|------|---------|
+| `groups_days_within_same_iso_week` | Mon/Wed/Sun of 2026-W16 merge into one row with summed totals |
+| `splits_across_iso_weeks_at_monday_boundary` | Sun 2026-04-12 (W15) and Mon 2026-04-13 (W16) go to separate rows |
+| `january_first_2027_is_w53_of_2026` | Year-boundary rollover — ISO year differs from calendar year |
+| `merges_same_model_across_days_into_one_entry` | Two entries for the same `(provider, model)` across days collapse to one |
+
+## Manual Smoke
+
+Run locally against the real DB (v0.1.3 + merged bug-bundles + this fix):
+
+```text
+$ llmusage weekly
+┌──────────┬─────────────────────┬───────────┬───────────┬────────────┐
+│ Date     │ Models              │     Input │    Output │ Cost (USD) │
+...
+│ 2026 W15 │ claude_code         │    14,340 │   284,214 │    $175.40 │
+│ 2026 W16 │ claude_code         │     3,316 │   989,525 │    $366.85 │
+```
+
+- **Before this PR**: `Error: Invalid column type Null at index: 0, name: period`. After: renders cleanly.
+- **Pipe tests**:
+  - `llmusage export --format csv | head` → exit 0, no panic.
+  - `llmusage export --format json | head` → exit 0, no panic.
+  - `llmusage export --format xml` → `Error: Unknown export format: 'xml'. Supported: csv, json`, exit 1.
+
+## Regression Risk
+
+- **Weekly cost aggregation drift.** The totals now come from Rust-side summation instead of SQL `SUM`. Both sum the same floating-point values; ordering differences could theoretically change the last ULP. Acceptable for cost display.
+- **`SIGPIPE` default behavior in all commands.** Any command writing to stdout/stderr now terminates with signal death instead of panic on `EPIPE`. This is the intended UX for pipelines (`| head`, `| grep`, etc.) and matches every other Unix tool. Scripts relying on the prior panic behavior would need to catch exit status 141 instead of 101 — unlikely to exist.
+- **`libc` dependency.** Small, stable, widely audited, already a transitive dep of `tokio`.
+
+## Rollback
+
+- `src/db/queries.rs`: reverting `query_weekly` to `strftime('%G-W%V', ...)` restores the NULL-crash regression — do not roll back without an alternate fix.
+- `src/main.rs` + `Cargo.toml` libc dep: reverting restores the EPIPE panic. Independent rollback is safe if the panic is preferred for some reason.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,6 +730,7 @@ dependencies = [
  "clap",
  "colored",
  "dirs",
+ "libc",
  "reqwest",
  "rusqlite",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,6 @@ serde_json = "1"
 tabled = "0.16"
 tokio = { version = "1", features = ["full"] }
 toml = "0.8"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -165,14 +165,71 @@ pub fn query_weekly(
     weeks: u32,
     provider: Option<&str>,
 ) -> Result<Vec<DailyRow>> {
-    // %G-W%V = ISO 8601 year + week number (Mon-based, 01..53).
-    // Requires SQLite >= 3.44 (rusqlite bundled build satisfies this).
-    query_grouped(
+    // SQLite's `%V`/`%G` strftime modifiers were added in SQLite 3.46 (May 2024).
+    // The bundled build in `rusqlite = 0.31` ships SQLite 3.45, where those
+    // modifiers silently return NULL and break row decoding. Instead, query
+    // per-day rows (portable on every SQLite version) and rebucket by ISO
+    // week in Rust using chrono's `iso_week`.
+    let daily = query_grouped(
         conn,
-        "strftime('%G-W%V', recorded_at)",
+        "DATE(recorded_at)",
         &format!("-{} days", weeks * 7),
         provider,
-    )
+    )?;
+    Ok(rebucket_daily_by_iso_week(daily))
+}
+
+fn rebucket_daily_by_iso_week(daily: Vec<DailyRow>) -> Vec<DailyRow> {
+    use chrono::{Datelike, NaiveDate};
+
+    // week_label -> (provider, model) -> accumulated ModelEntry
+    let mut buckets: BTreeMap<String, BTreeMap<(String, String), ModelEntry>> = BTreeMap::new();
+
+    for row in daily {
+        let Ok(date) = NaiveDate::parse_from_str(&row.date, "%Y-%m-%d") else {
+            // DATE(recorded_at) always yields YYYY-MM-DD; skip defensively if not.
+            continue;
+        };
+        let iw = date.iso_week();
+        let label = format!("{}-W{:02}", iw.year(), iw.week());
+        let week = buckets.entry(label).or_default();
+        for entry in row.model_entries {
+            let key = (entry.provider.clone(), entry.model.clone());
+            let agg = week.entry(key).or_insert_with(|| ModelEntry {
+                provider: entry.provider.clone(),
+                model: entry.model.clone(),
+                input_tokens: 0,
+                output_tokens: 0,
+                cost: 0.0,
+            });
+            agg.input_tokens += entry.input_tokens;
+            agg.output_tokens += entry.output_tokens;
+            agg.cost += entry.cost;
+        }
+    }
+
+    let mut out: Vec<DailyRow> = Vec::with_capacity(buckets.len());
+    for (label, entries_by_model) in buckets {
+        let mut row = DailyRow {
+            date: label,
+            models: Vec::new(),
+            model_entries: Vec::new(),
+            total_input: 0,
+            total_output: 0,
+            total_cost: 0.0,
+        };
+        for (_, entry) in entries_by_model {
+            if !row.models.contains(&entry.model) {
+                row.models.push(entry.model.clone());
+            }
+            row.total_input += entry.input_tokens;
+            row.total_output += entry.output_tokens;
+            row.total_cost += entry.cost;
+            row.model_entries.push(entry);
+        }
+        out.push(row);
+    }
+    out
 }
 
 pub fn query_monthly(
@@ -258,4 +315,76 @@ fn query_grouped(
     }
 
     Ok(map.into_values().collect())
+}
+
+#[cfg(test)]
+mod iso_week_tests {
+    use super::*;
+
+    fn day(date: &str, model: &str, input: i64, output: i64, cost: f64) -> DailyRow {
+        DailyRow {
+            date: date.to_string(),
+            models: vec![model.to_string()],
+            model_entries: vec![ModelEntry {
+                provider: "p".to_string(),
+                model: model.to_string(),
+                input_tokens: input,
+                output_tokens: output,
+                cost,
+            }],
+            total_input: input,
+            total_output: output,
+            total_cost: cost,
+        }
+    }
+
+    #[test]
+    fn groups_days_within_same_iso_week() {
+        // 2026-04-13 (Mon) through 2026-04-19 (Sun) = ISO week 16 of 2026.
+        let daily = vec![
+            day("2026-04-13", "m", 10, 5, 0.10),
+            day("2026-04-15", "m", 20, 5, 0.20),
+            day("2026-04-19", "m", 30, 10, 0.30),
+        ];
+        let weekly = rebucket_daily_by_iso_week(daily);
+        assert_eq!(weekly.len(), 1);
+        assert_eq!(weekly[0].date, "2026-W16");
+        assert_eq!(weekly[0].total_input, 60);
+        assert_eq!(weekly[0].total_output, 20);
+        assert!((weekly[0].total_cost - 0.60).abs() < 1e-9);
+    }
+
+    #[test]
+    fn splits_across_iso_weeks_at_monday_boundary() {
+        // Sunday 2026-04-12 = W15; Monday 2026-04-13 = W16.
+        let daily = vec![
+            day("2026-04-12", "m", 10, 0, 0.10),
+            day("2026-04-13", "m", 20, 0, 0.20),
+        ];
+        let weekly = rebucket_daily_by_iso_week(daily);
+        assert_eq!(weekly.len(), 2);
+        assert_eq!(weekly[0].date, "2026-W15");
+        assert_eq!(weekly[1].date, "2026-W16");
+    }
+
+    #[test]
+    fn january_first_2027_is_w53_of_2026() {
+        // 2027-01-01 is Friday; ISO week 53 of 2026.
+        let daily = vec![day("2027-01-01", "m", 1, 1, 0.01)];
+        let weekly = rebucket_daily_by_iso_week(daily);
+        assert_eq!(weekly[0].date, "2026-W53");
+    }
+
+    #[test]
+    fn merges_same_model_across_days_into_one_entry() {
+        let daily = vec![
+            day("2026-04-13", "m", 10, 5, 0.10),
+            day("2026-04-15", "m", 20, 5, 0.20),
+        ];
+        let weekly = rebucket_daily_by_iso_week(daily);
+        assert_eq!(weekly[0].model_entries.len(), 1);
+        let entry = &weekly[0].model_entries[0];
+        assert_eq!(entry.input_tokens, 30);
+        assert_eq!(entry.output_tokens, 10);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,8 +131,25 @@ enum Commands {
     },
 }
 
+/// Rust's stdlib sets `SIGPIPE` to `SIG_IGN` at startup, so writes to a closed
+/// pipe (e.g. `llmusage export | head`) turn into `EPIPE` errors — and
+/// `println!` then panics. For a CLI the natural behavior is silent termination
+/// when the reader goes away, matching `cat`, `grep`, etc.
+#[cfg(unix)]
+fn reset_sigpipe() {
+    // SAFETY: setting a signal handler to SIG_DFL is always safe and has no
+    // undefined behavior.
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+    }
+}
+
+#[cfg(not(unix))]
+fn reset_sigpipe() {}
+
 #[tokio::main]
 async fn main() -> Result<()> {
+    reset_sigpipe();
     let cli = Cli::parse();
     let cfg = config::load_config()?;
     let db = db::Database::open(&cfg.db_path)?;


### PR DESCRIPTION
## Summary

Two runtime regressions surfaced during local testing of v0.1.3 + the merged bug-bundles:

1. **`llmusage weekly` crashes** with `Error: Invalid column type Null at index: 0, name: period`. The earlier fix (#78 / #34) moved weekly grouping to \`strftime('%G-W%V', recorded_at)\`. Those modifiers were added in **SQLite 3.46** (May 2024); \`rusqlite = 0.31\` bundles **SQLite 3.45**, which silently returns \`NULL\` for unknown modifiers and crashes row decoding.
2. **Broken-pipe panic** when piping output into \`head\`, e.g. \`llmusage export --format csv | head\`. Rust's stdlib sets \`SIGPIPE\` to \`SIG_IGN\` at startup, converting EPIPE into an error that \`println!\` then unwraps into a panic. Expected CLI behavior is silent termination.

## Changes

- **\`src/db/queries.rs\`** — replace SQL-side \`%G-W%V\` with a Rust-side rebucketing over per-day rows (\`DATE(recorded_at)\`). Uses \`chrono::Datelike::iso_week\`, portable on any bundled SQLite.
- **\`src/main.rs\`** — \`reset_sigpipe()\` at \`main\` entry (no-op on non-unix) calls \`libc::signal(SIGPIPE, SIG_DFL)\`.
- **\`Cargo.toml\`** — add \`libc = \"0.2\"\` under \`[target.'cfg(unix)'.dependencies]\`.
- **\`.specs/{tasks,implementation,validation}/weekly-iso-and-sigpipe/\`** — task / impl / validation docs following the repo convention.

## Test plan

- [x] \`cargo fmt --all --check\`
- [x] \`cargo build --release\`
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] \`cargo test\` (37 pre-existing + 4 new = 41 tests). New cases: same-week aggregation, Monday-boundary split, year-boundary (2027-01-01 → 2026-W53), cross-day model merge.
- [x] \`llmusage weekly\` renders correctly against a real DB (previously crashed).
- [x] \`llmusage export --format csv | head\` exits 0, no panic. Same for \`--format json\`.
- [x] \`llmusage export --format xml\` still errors cleanly (from PR #78).

## Notes

The spec in PR #78 claimed \`%V\`/\`%G\` land in SQLite 3.44 — that was incorrect (they landed in 3.46). The new \`.specs/\` trio records the correction.