### PR TITLE
chore: bump to v0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,7 +722,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llmusage"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llmusage"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "Track token usage and costs across AI providers"
 license = "MIT"


### PR DESCRIPTION
## Summary

Patch bump rolling up the recent bug-fix PRs:

- #78 Quick-bug bundle — save_config guard (#33), negative token formatting (#30), ISO week grouping (#34), export format validation (#36)
- #79 Fallback pricing — deterministic matching + cache token costs (#55, #54)
- #80 Data correctness — CSV escaping (#31), pricing OnceLock cache (#32), daily totals + deterministic ordering (#48)
- #81 Weekly ISO crash (SQLite 3.45 vs %V/%G) + broken-pipe panic

All fixes are patch-level (no public-API changes, no schema migration). After merge, tagging `v0.1.4` will trigger the release workflow, which in turn opens the CHANGELOG PR (per #77).

## Test plan

- [x] `cargo build --release`
- [x] `cargo test` (41 passed)
- [x] Manual smoke on real DB: `llmusage weekly`, `llmusage daily`, `llmusage export --format {csv,json}`, `llmusage export --format xml` (errors), pipe-to-head exits 0