### PR TITLE
Add schema migrations

### DIFF
--- a/.specs/implementation/schema-migrations.md
+++ b/.specs/implementation/schema-migrations.md
@@ -1,0 +1,76 @@
+# Schema Migration System
+
+## Goal
+
+Add migration and version tracking for SQLite schema upgrades without requiring users to delete their existing database or lose historical data.
+
+## Non-Goals
+
+- No new user-facing CLI or command surface
+- No unrelated schema redesign
+- No bundling of richer token fields or new usage columns into this change
+
+## Current State
+
+- [`initialize()`](/Users/openrijal/conductor/workspaces/llmusage/bandung/src/db/schema.rs:4) uses `CREATE TABLE IF NOT EXISTS` and `CREATE INDEX IF NOT EXISTS`.
+- Existing databases are opened through [Database::open()](/Users/openrijal/conductor/workspaces/llmusage/bandung/src/db/mod.rs:13) and never receive explicit schema upgrades.
+- Any future table or index evolution will not be applied automatically to already-initialized databases.
+
+## Design
+
+- Use `PRAGMA user_version` as the schema version store.
+- Define `LATEST_SCHEMA_VERSION = 2`.
+- Treat pre-version databases with `usage_records` present as legacy schema version `1`.
+- Fresh databases initialize directly to version `2`.
+
+## Required Functions
+
+- `initialize(conn)`
+- `current_schema_version(conn) -> Result<i64>`
+- `set_schema_version(conn, version) -> Result<()>`
+- `create_schema_v1(conn) -> Result<()>`
+- `migrate(conn, from, to) -> Result<()>`
+- `migrate_v1_to_v2(conn) -> Result<()>`
+
+## Migration Rules
+
+- Run all migration work inside a transaction.
+- Only bump the schema version after the migration completes successfully.
+- Fail closed on unknown future versions.
+- Keep startup reopen-safe and idempotent.
+
+## Version Definitions
+
+- `1`: Legacy current table and index shape, with no explicit version metadata in existing installs
+- `2`: Migration-managed schema baseline
+
+## v1 -> v2 Scope
+
+- Keep the current `usage_records` column set unchanged.
+- Recreate or normalize indexes under explicit migration control if needed.
+- Do not delete user data.
+
+## Call Flow
+
+- `Database::open()` opens the SQLite database.
+- `Database::open()` enables WAL and foreign key pragmas.
+- `Database::open()` calls a migration-aware `schema::initialize()`.
+- `schema::initialize()` ensures the database is at `LATEST_SCHEMA_VERSION` before returning.
+
+## Risks
+
+- Legacy database detection could misclassify an unusual local database state.
+- A partially applied migration would leave the database in an inconsistent state if not fully transactional.
+- Future schema edits may still drift if version updates are not added alongside DB changes.
+
+## Follow-On Work Enabled
+
+- `#50` Dedup index changes
+- `#57` OpenAI collector token shape expansion
+- `#58` Database purge and info commands
+
+## Assumptions
+
+- `PRAGMA user_version` is sufficient and preferred over a dedicated schema history table for this project size.
+- The first migration-capable release should establish the managed baseline as schema version `2`.
+- This issue should stay internal to the DB layer and not widen scope into adjacent feature work.

--- a/.specs/tasks/openrijal-issue-triage.md
+++ b/.specs/tasks/openrijal-issue-triage.md
@@ -1,0 +1,48 @@
+# Issue Triage
+
+## Branch
+
+`openrijal/issue-triage`
+
+## Recommendation
+
+Recommend GitHub issue `#56`.
+
+Link: https://github.com/openrijal/llmusage/issues/56
+
+## Why This Next
+
+- The current DB boot path has no migration or schema version tracking.
+- Future schema changes will break existing installs or silently fail to apply.
+- This unblocks safer work on dedup/index changes, richer token fields, and DB cleanup or management.
+
+## Alternatives Considered
+
+- `#53` Add environment variable support for API key configuration
+- `#35` Codex collector uses hardcoded model name instead of actual model
+- `#58` Add llmusage reset/purge command for database management
+
+## Decision
+
+Priority order:
+
+1. `#56`
+2. `#50`
+3. `#57`
+4. `#58`
+
+## Current Code References
+
+- [src/db/schema.rs](/Users/openrijal/conductor/workspaces/llmusage/bandung/src/db/schema.rs:4)
+- [src/db/mod.rs](/Users/openrijal/conductor/workspaces/llmusage/bandung/src/db/mod.rs:13)
+
+Supporting references for related or partially stale issues:
+
+- [src/collectors/openai.rs](/Users/openrijal/conductor/workspaces/llmusage/bandung/src/collectors/openai.rs:45)
+- [src/collectors/codex.rs](/Users/openrijal/conductor/workspaces/llmusage/bandung/src/collectors/codex.rs:87)
+
+## Assumptions
+
+- `.specs` is the authoritative spec root for this workspace.
+- The next recommended issue remains `#56`.
+- The product PRD does not need changes for this triage decision.

--- a/.specs/validation/schema-migrations.md
+++ b/.specs/validation/schema-migrations.md
@@ -1,0 +1,42 @@
+# Validation Plan
+
+## Acceptance Criteria
+
+- A fresh database gets the latest schema version.
+- A legacy database upgrades without data loss.
+- Reopening an upgraded database is a no-op.
+- A migration failure rolls back cleanly.
+- Existing commands still work after upgrade.
+
+## Test Scenarios
+
+1. Fresh temporary database created through the normal open path
+2. Legacy database seeded with the old `usage_records` schema and no version marker
+3. Already-upgraded database reopened with no additional migration work
+4. Simulated migration failure to confirm rollback behavior
+5. Read and query smoke test after migration
+
+## Commands To Run
+
+- `cargo build`
+- `cargo clippy`
+- `cargo test`
+
+## Evidence To Record
+
+- Schema version before and after initialization
+- Presence of expected tables and indexes
+- Row counts preserved across migration
+- Any migration log or error text captured during testing
+
+## Out Of Scope
+
+- Performance benchmarking
+- Release automation
+- Non-SQLite backends
+
+## Assumptions
+
+- Validation will be done against temporary or disposable local databases.
+- Existing reporting commands are sufficient for post-migration smoke testing.
+- No PRD changes are required for this spec-only task.

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -1,30 +1,281 @@
-use anyhow::Result;
+use anyhow::{bail, Result};
 use rusqlite::Connection;
 
-pub fn initialize(conn: &Connection) -> Result<()> {
-    conn.execute_batch(
-        "
-        CREATE TABLE IF NOT EXISTS usage_records (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            provider TEXT NOT NULL,
-            model TEXT NOT NULL,
-            input_tokens INTEGER NOT NULL,
-            output_tokens INTEGER NOT NULL,
-            cache_read_tokens INTEGER DEFAULT 0,
-            cache_write_tokens INTEGER DEFAULT 0,
-            cost_usd REAL,
-            session_id TEXT,
-            recorded_at TEXT NOT NULL,
-            collected_at TEXT NOT NULL,
-            metadata TEXT
-        );
+const LATEST_SCHEMA_VERSION: i64 = 2;
 
-        CREATE INDEX IF NOT EXISTS idx_provider ON usage_records(provider);
-        CREATE INDEX IF NOT EXISTS idx_recorded_at ON usage_records(recorded_at);
-        CREATE INDEX IF NOT EXISTS idx_model ON usage_records(model);
-        CREATE INDEX IF NOT EXISTS idx_provider_recorded ON usage_records(provider, recorded_at);
-        CREATE UNIQUE INDEX IF NOT EXISTS idx_dedup ON usage_records(provider, model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, recorded_at, COALESCE(session_id, ''));
-        ",
-    )?;
+const CREATE_USAGE_RECORDS_TABLE_SQL: &str = "
+    CREATE TABLE IF NOT EXISTS usage_records (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        provider TEXT NOT NULL,
+        model TEXT NOT NULL,
+        input_tokens INTEGER NOT NULL,
+        output_tokens INTEGER NOT NULL,
+        cache_read_tokens INTEGER DEFAULT 0,
+        cache_write_tokens INTEGER DEFAULT 0,
+        cost_usd REAL,
+        session_id TEXT,
+        recorded_at TEXT NOT NULL,
+        collected_at TEXT NOT NULL,
+        metadata TEXT
+    );
+";
+
+const CREATE_INDEXES_SQL: &str = "
+    CREATE INDEX IF NOT EXISTS idx_provider ON usage_records(provider);
+    CREATE INDEX IF NOT EXISTS idx_recorded_at ON usage_records(recorded_at);
+    CREATE INDEX IF NOT EXISTS idx_model ON usage_records(model);
+    CREATE INDEX IF NOT EXISTS idx_provider_recorded ON usage_records(provider, recorded_at);
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_dedup ON usage_records(
+        provider,
+        model,
+        input_tokens,
+        output_tokens,
+        cache_read_tokens,
+        cache_write_tokens,
+        recorded_at,
+        COALESCE(session_id, '')
+    );
+";
+
+pub fn initialize(conn: &Connection) -> Result<()> {
+    let current = current_schema_version(conn)?;
+
+    if current > LATEST_SCHEMA_VERSION {
+        bail!(
+            "Database schema version {} is newer than supported version {}",
+            current,
+            LATEST_SCHEMA_VERSION
+        );
+    }
+
+    if current == 0 {
+        if table_exists(conn, "usage_records")? {
+            migrate(conn, 1, LATEST_SCHEMA_VERSION)?;
+        } else {
+            let tx = conn.unchecked_transaction()?;
+            create_schema_v1(&tx)?;
+            set_schema_version(&tx, LATEST_SCHEMA_VERSION)?;
+            tx.commit()?;
+        }
+        return Ok(());
+    }
+
+    migrate(conn, current, LATEST_SCHEMA_VERSION)
+}
+
+fn current_schema_version(conn: &Connection) -> Result<i64> {
+    Ok(conn.pragma_query_value(None, "user_version", |row| row.get(0))?)
+}
+
+fn set_schema_version(conn: &Connection, version: i64) -> Result<()> {
+    conn.pragma_update(None, "user_version", version)?;
     Ok(())
+}
+
+fn create_schema_v1(conn: &Connection) -> Result<()> {
+    conn.execute_batch(CREATE_USAGE_RECORDS_TABLE_SQL)?;
+    conn.execute_batch(CREATE_INDEXES_SQL)?;
+    Ok(())
+}
+
+fn migrate(conn: &Connection, from: i64, to: i64) -> Result<()> {
+    if from > to {
+        bail!(
+            "Cannot migrate database backwards from version {} to {}",
+            from,
+            to
+        );
+    }
+
+    if from == to {
+        return Ok(());
+    }
+
+    let tx = conn.unchecked_transaction()?;
+    let mut version = from;
+
+    while version < to {
+        match version {
+            1 => migrate_v1_to_v2(&tx)?,
+            _ => bail!("No migration path from schema version {}", version),
+        }
+        version += 1;
+        set_schema_version(&tx, version)?;
+    }
+
+    tx.commit()?;
+    Ok(())
+}
+
+fn migrate_v1_to_v2(conn: &Connection) -> Result<()> {
+    conn.execute_batch(CREATE_INDEXES_SQL)?;
+    Ok(())
+}
+
+fn table_exists(conn: &Connection, name: &str) -> Result<bool> {
+    let exists = conn.query_row(
+        "SELECT EXISTS(
+            SELECT 1
+            FROM sqlite_master
+            WHERE type = 'table' AND name = ?1
+        )",
+        [name],
+        |row| row.get::<_, i64>(0),
+    )?;
+    Ok(exists != 0)
+}
+
+#[cfg(test)]
+fn index_exists(conn: &Connection, name: &str) -> Result<bool> {
+    let exists = conn.query_row(
+        "SELECT EXISTS(
+            SELECT 1
+            FROM sqlite_master
+            WHERE type = 'index' AND name = ?1
+        )",
+        [name],
+        |row| row.get::<_, i64>(0),
+    )?;
+    Ok(exists != 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_db_path(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "llmusage-{name}-{}-{nanos}.sqlite",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn initializes_fresh_database_to_latest_version() {
+        let conn = Connection::open_in_memory().unwrap();
+
+        initialize(&conn).unwrap();
+
+        assert_eq!(
+            current_schema_version(&conn).unwrap(),
+            LATEST_SCHEMA_VERSION
+        );
+        assert!(table_exists(&conn, "usage_records").unwrap());
+        assert!(index_exists(&conn, "idx_dedup").unwrap());
+    }
+
+    #[test]
+    fn upgrades_legacy_database_without_data_loss() {
+        let conn = Connection::open_in_memory().unwrap();
+        create_schema_v1(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO usage_records (
+                provider, model, input_tokens, output_tokens,
+                cache_read_tokens, cache_write_tokens, cost_usd, session_id,
+                recorded_at, collected_at, metadata
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+            rusqlite::params![
+                "openai",
+                "gpt-4o-mini",
+                10,
+                5,
+                0,
+                0,
+                0.12_f64,
+                Option::<String>::None,
+                "2026-04-18",
+                "2026-04-18T12:00:00Z",
+                Option::<String>::None,
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(current_schema_version(&conn).unwrap(), 0);
+
+        initialize(&conn).unwrap();
+
+        assert_eq!(
+            current_schema_version(&conn).unwrap(),
+            LATEST_SCHEMA_VERSION
+        );
+        let rows: i64 = conn
+            .query_row("SELECT COUNT(*) FROM usage_records", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(rows, 1);
+        assert!(index_exists(&conn, "idx_provider_recorded").unwrap());
+    }
+
+    #[test]
+    fn reopening_latest_database_is_a_noop() {
+        let path = temp_db_path("schema-reopen");
+
+        {
+            let conn = Connection::open(&path).unwrap();
+            initialize(&conn).unwrap();
+            conn.execute(
+                "INSERT INTO usage_records (
+                    provider, model, input_tokens, output_tokens,
+                    cache_read_tokens, cache_write_tokens, cost_usd, session_id,
+                    recorded_at, collected_at, metadata
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+                rusqlite::params![
+                    "anthropic",
+                    "claude-sonnet-4-6",
+                    20,
+                    8,
+                    3,
+                    0,
+                    0.45_f64,
+                    "session-1",
+                    "2026-04-18",
+                    "2026-04-18T12:30:00Z",
+                    "{\"k\":\"v\"}",
+                ],
+            )
+            .unwrap();
+        }
+
+        {
+            let conn = Connection::open(&path).unwrap();
+            initialize(&conn).unwrap();
+            assert_eq!(
+                current_schema_version(&conn).unwrap(),
+                LATEST_SCHEMA_VERSION
+            );
+            let rows: i64 = conn
+                .query_row("SELECT COUNT(*) FROM usage_records", [], |row| row.get(0))
+                .unwrap();
+            assert_eq!(rows, 1);
+        }
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn migration_failure_rolls_back_version_bump() {
+        let conn = Connection::open_in_memory().unwrap();
+        set_schema_version(&conn, 1).unwrap();
+
+        let err = initialize(&conn).unwrap_err();
+
+        assert!(err.to_string().contains("usage_records"));
+        assert_eq!(current_schema_version(&conn).unwrap(), 1);
+        assert!(!index_exists(&conn, "idx_provider").unwrap());
+    }
+
+    #[test]
+    fn rejects_unknown_future_schema_versions() {
+        let conn = Connection::open_in_memory().unwrap();
+        set_schema_version(&conn, LATEST_SCHEMA_VERSION + 1).unwrap();
+
+        let err = initialize(&conn).unwrap_err();
+
+        assert!(err.to_string().contains("newer than supported"));
+    }
 }


### PR DESCRIPTION
## Summary
- add migration-aware DB initialization using `PRAGMA user_version`
- auto-upgrade legacy unversioned databases to schema version 2
- add specs and tests for fresh init, upgrade, reopen, rollback, and future-version rejection

## Testing
- cargo fmt
- cargo test
- cargo clippy --all-targets --all-features

Closes #56