### PR TITLE
Prefer environment variables for API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ llmusage --version
 # Configure an API provider (optional — local tools are auto-detected)
 llmusage config --set anthropic_api_key=sk-ant-...
 
+# Or prefer environment variables for secrets
+export ANTHROPIC_API_KEY=sk-ant-...
+export OPENAI_API_KEY=sk-...
+
 # Sync usage data from all configured/detected providers
 llmusage sync
 
@@ -176,6 +180,17 @@ llmusage config --set claude_code_enabled=false
 
 `llmusage config --list` also shows auto-detected local collectors and strict-mode unsupported local IDE tooling such as Windsurf and VS Code.
 
+Environment variables override config file values when present:
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+export OPENAI_API_KEY=sk-...
+export GEMINI_API_KEY=AIza...
+export OLLAMA_HOST=http://192.168.1.10:11434
+```
+
+This is the preferred way to provide API keys because secrets do not need to be written to disk.
+
 For local SQLite IDE collectors that live under a platform config directory:
 
 - **macOS**: `<config_dir>` resolves to `~/Library/Application Support`
@@ -206,6 +221,8 @@ TOML config at platform-specific location:
 | `gemini_api_key` | Gemini API key | None |
 | `ollama_host` | Ollama server URL | `http://localhost:11434` |
 | `claude_code_enabled` | Parse Claude Code session logs | `true` |
+
+On Unix, `llmusage` restricts `config.toml` permissions to `0600` when it reads or writes the file. Existing API key fields still work, but environment variables are safer for secrets.
 
 ## Uninstall
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
@@ -43,22 +43,30 @@ fn config_file() -> PathBuf {
 
 pub fn load_config() -> Result<Config> {
     let path = config_file();
-    if path.exists() {
+    let mut cfg = if path.exists() {
         let content = std::fs::read_to_string(&path)?;
         let mut cfg: Config = toml::from_str(&content)?;
-        cfg.config_path = path;
-        Ok(cfg)
+        cfg.config_path = path.clone();
+        cfg
     } else {
-        Ok(Config {
+        Config {
             db_path: default_db_path(),
             anthropic_api_key: None,
             openai_api_key: None,
             gemini_api_key: None,
             ollama_host: None,
             claude_code_enabled: true,
-            config_path: path,
-        })
+            config_path: path.clone(),
+        }
+    };
+
+    apply_env_overrides(&mut cfg);
+
+    if path.exists() {
+        tighten_config_permissions(&path)?;
     }
+
+    Ok(cfg)
 }
 
 pub fn save_config(cfg: &Config) -> Result<()> {
@@ -69,6 +77,7 @@ pub fn save_config(cfg: &Config) -> Result<()> {
     std::fs::create_dir_all(dir)?;
     let content = toml::to_string_pretty(cfg)?;
     std::fs::write(&cfg.config_path, content)?;
+    tighten_config_permissions(&cfg.config_path)?;
     Ok(())
 }
 
@@ -97,7 +106,9 @@ pub fn print_config(cfg: &Config) {
     println!("{}", "Providers:".bold());
     println!(
         "  anthropic:    {}",
-        if cfg.anthropic_api_key.is_some() {
+        if env_var_present("ANTHROPIC_API_KEY") {
+            "configured (env)".green()
+        } else if cfg.anthropic_api_key.is_some() {
             "configured".green()
         } else {
             "not set".dimmed()
@@ -105,7 +116,9 @@ pub fn print_config(cfg: &Config) {
     );
     println!(
         "  openai:       {}",
-        if cfg.openai_api_key.is_some() {
+        if env_var_present("OPENAI_API_KEY") {
+            "configured (env)".green()
+        } else if cfg.openai_api_key.is_some() {
             "configured".green()
         } else {
             "not set".dimmed()
@@ -113,7 +126,9 @@ pub fn print_config(cfg: &Config) {
     );
     println!(
         "  gemini:       {}",
-        if cfg.gemini_api_key.is_some() {
+        if env_var_present("GEMINI_API_KEY") {
+            "configured (env)".green()
+        } else if cfg.gemini_api_key.is_some() {
             "configured".green()
         } else {
             "not set".dimmed()
@@ -121,8 +136,14 @@ pub fn print_config(cfg: &Config) {
     );
     println!(
         "  ollama:       {}",
-        if cfg.ollama_host.is_some() {
-            cfg.ollama_host.as_deref().unwrap().to_string().green()
+        if env_var_present("OLLAMA_HOST") {
+            "configured (env)".green()
+        } else if cfg.ollama_host.is_some() {
+            cfg.ollama_host
+                .as_deref()
+                .unwrap_or_default()
+                .to_string()
+                .green()
         } else {
             "not set (default: http://localhost:11434)".dimmed()
         }
@@ -135,4 +156,180 @@ pub fn print_config(cfg: &Config) {
             "disabled".dimmed()
         }
     );
+}
+
+fn apply_env_overrides(cfg: &mut Config) {
+    if let Some(value) = env_var_value("ANTHROPIC_API_KEY") {
+        cfg.anthropic_api_key = Some(value);
+    }
+    if let Some(value) = env_var_value("OPENAI_API_KEY") {
+        cfg.openai_api_key = Some(value);
+    }
+    if let Some(value) = env_var_value("GEMINI_API_KEY") {
+        cfg.gemini_api_key = Some(value);
+    }
+    if let Some(value) = env_var_value("OLLAMA_HOST") {
+        cfg.ollama_host = Some(value);
+    }
+}
+
+fn env_var_value(name: &str) -> Option<String> {
+    std::env::var(name).ok().filter(|value| !value.is_empty())
+}
+
+fn env_var_present(name: &str) -> bool {
+    env_var_value(name).is_some()
+}
+
+#[cfg(unix)]
+fn tighten_config_permissions(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let permissions = std::fs::Permissions::from_mode(0o600);
+    std::fs::set_permissions(path, permissions)?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn tighten_config_permissions(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    struct EnvGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var(key).ok();
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.previous {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
+
+    fn temp_path(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "llmusage-{name}-{}-{nanos}.toml",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn env_overrides_file_values() {
+        let _anthropic = EnvGuard::set("ANTHROPIC_API_KEY", "env-anthropic");
+        let _openai = EnvGuard::set("OPENAI_API_KEY", "env-openai");
+        let _gemini = EnvGuard::set("GEMINI_API_KEY", "env-gemini");
+        let _ollama = EnvGuard::set("OLLAMA_HOST", "http://env-host");
+
+        let mut cfg = Config {
+            db_path: "db.sqlite".to_string(),
+            anthropic_api_key: Some("file-anthropic".to_string()),
+            openai_api_key: Some("file-openai".to_string()),
+            gemini_api_key: Some("file-gemini".to_string()),
+            ollama_host: Some("http://file-host".to_string()),
+            claude_code_enabled: true,
+            config_path: PathBuf::from("config.toml"),
+        };
+
+        apply_env_overrides(&mut cfg);
+
+        assert_eq!(cfg.anthropic_api_key.as_deref(), Some("env-anthropic"));
+        assert_eq!(cfg.openai_api_key.as_deref(), Some("env-openai"));
+        assert_eq!(cfg.gemini_api_key.as_deref(), Some("env-gemini"));
+        assert_eq!(cfg.ollama_host.as_deref(), Some("http://env-host"));
+    }
+
+    #[test]
+    fn empty_env_vars_do_not_override_file_values() {
+        let _openai = EnvGuard::set("OPENAI_API_KEY", "");
+
+        let mut cfg = Config {
+            db_path: "db.sqlite".to_string(),
+            anthropic_api_key: None,
+            openai_api_key: Some("file-openai".to_string()),
+            gemini_api_key: None,
+            ollama_host: None,
+            claude_code_enabled: true,
+            config_path: PathBuf::from("config.toml"),
+        };
+
+        apply_env_overrides(&mut cfg);
+
+        assert_eq!(cfg.openai_api_key.as_deref(), Some("file-openai"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn save_config_restricts_permissions_to_owner() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = temp_path("save-config");
+        let cfg = Config {
+            db_path: "db.sqlite".to_string(),
+            anthropic_api_key: Some("secret".to_string()),
+            openai_api_key: None,
+            gemini_api_key: None,
+            ollama_host: None,
+            claude_code_enabled: true,
+            config_path: path.clone(),
+        };
+
+        save_config(&cfg).unwrap();
+
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn load_config_tightens_existing_file_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = temp_path("load-config");
+        std::fs::write(
+            &path,
+            r#"
+db_path = "db.sqlite"
+openai_api_key = "secret"
+"#,
+        )
+        .unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let mut cfg: Config = toml::from_str(&content).unwrap();
+        cfg.config_path = path.clone();
+        apply_env_overrides(&mut cfg);
+        tighten_config_permissions(&path).unwrap();
+
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+
+        let _ = std::fs::remove_file(path);
+    }
 }


### PR DESCRIPTION
## Summary
- override file-based API settings from environment variables when present
- tighten `config.toml` permissions to `0600` on Unix reads and writes
- document environment variables as the preferred way to provide API keys

## Testing
- cargo fmt
- cargo test
- cargo clippy --all-targets --all-features

Closes #45