### PR TITLE
feat(providers): add OpenRouter and DeepSeek collectors

### DIFF
--- a/src/collectors/deepseek.rs
+++ b/src/collectors/deepseek.rs
@@ -1,0 +1,101 @@
+//! DeepSeek collector.
+//!
+//! DeepSeek does not expose a public historical usage API. `/user/balance`
+//! returns only the current balance. As a result, this collector validates
+//! the API key (by calling `/user/balance`) and returns no `UsageRecord`s.
+//! If DeepSeek adds a per-model usage endpoint in the future, this is the
+//! place to plug it in.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use super::Collector;
+use crate::models::UsageRecord;
+
+pub struct DeepSeekCollector {
+    api_key: String,
+    client: reqwest::Client,
+}
+
+impl DeepSeekCollector {
+    pub fn new(api_key: String) -> Self {
+        Self {
+            api_key,
+            client: reqwest::Client::new(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct BalanceResponse {
+    #[serde(default)]
+    is_available: bool,
+    #[serde(default)]
+    balance_infos: Vec<BalanceInfo>,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct BalanceInfo {
+    #[serde(default)]
+    currency: String,
+    #[serde(default)]
+    total_balance: String,
+}
+
+#[async_trait]
+impl Collector for DeepSeekCollector {
+    fn name(&self) -> &str {
+        "deepseek"
+    }
+
+    async fn collect(&self) -> Result<Vec<UsageRecord>> {
+        let resp = self
+            .client
+            .get("https://api.deepseek.com/user/balance")
+            .bearer_auth(&self.api_key)
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!("DeepSeek balance API error {}: {}", status, body);
+        }
+
+        // Parse to verify a sane response; we don't surface balance as a
+        // UsageRecord because there is no historical per-model data.
+        let _balance: BalanceResponse = resp.json().await?;
+        Ok(Vec::new())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_balance_response() {
+        let sample = r#"{
+            "is_available": true,
+            "balance_infos": [
+                {"currency": "USD", "total_balance": "10.00", "granted_balance": "5.00", "topped_up_balance": "5.00"}
+            ]
+        }"#;
+        let parsed: BalanceResponse = serde_json::from_str(sample).unwrap();
+        assert!(parsed.is_available);
+        assert_eq!(parsed.balance_infos.len(), 1);
+        assert_eq!(parsed.balance_infos[0].currency, "USD");
+        assert_eq!(parsed.balance_infos[0].total_balance, "10.00");
+    }
+
+    #[test]
+    fn handles_missing_fields() {
+        let sample = r#"{}"#;
+        let parsed: BalanceResponse = serde_json::from_str(sample).unwrap();
+        assert!(!parsed.is_available);
+        assert!(parsed.balance_infos.is_empty());
+    }
+}

--- a/src/collectors/mod.rs
+++ b/src/collectors/mod.rs
@@ -2,11 +2,13 @@ pub mod anthropic;
 pub mod claude_code;
 pub mod codex;
 pub mod cursor;
+pub mod deepseek;
 pub mod gemini;
 pub mod gemini_cli;
 pub mod ollama;
 pub mod openai;
 pub mod opencode;
+pub mod openrouter;
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -60,6 +62,18 @@ pub fn get_collectors(
     if should_include("gemini") {
         if let Some(ref key) = cfg.gemini_api_key {
             collectors.push(Box::new(gemini::GeminiCollector::new(key.clone())));
+        }
+    }
+
+    if should_include("openrouter") {
+        if let Some(ref key) = cfg.openrouter_api_key {
+            collectors.push(Box::new(openrouter::OpenRouterCollector::new(key.clone())));
+        }
+    }
+
+    if should_include("deepseek") {
+        if let Some(ref key) = cfg.deepseek_api_key {
+            collectors.push(Box::new(deepseek::DeepSeekCollector::new(key.clone())));
         }
     }
 
@@ -223,6 +237,23 @@ pub fn explain_provider_filter(cfg: &Config, provider_filter: &str) -> String {
                     .to_string()
             }
         }
+        "openrouter" => {
+            if cfg.openrouter_api_key.is_some() {
+                "Provider 'openrouter' is configured but returned no active collector.".to_string()
+            } else {
+                "Provider 'openrouter' is supported but requires `openrouter_api_key` in config."
+                    .to_string()
+            }
+        }
+        "deepseek" => {
+            if cfg.deepseek_api_key.is_some() {
+                "Provider 'deepseek' is configured, but DeepSeek does not expose a historical usage API; the collector only validates the key."
+                    .to_string()
+            } else {
+                "Provider 'deepseek' is supported but requires `deepseek_api_key` in config."
+                    .to_string()
+            }
+        }
         "ollama" => "Provider 'ollama' is supported, but no collector could be activated.".to_string(),
         "claude_code" => {
             if cfg.claude_code_enabled {
@@ -266,7 +297,7 @@ pub fn explain_provider_filter(cfg: &Config, provider_filter: &str) -> String {
                 .to_string()
         }
         other => format!(
-            "Unknown provider '{}'. Known providers: anthropic, openai, gemini, ollama, claude_code, codex, opencode, gemini_cli, antigravity, cursor, windsurf, vscode",
+            "Unknown provider '{}'. Known providers: anthropic, openai, gemini, openrouter, deepseek, ollama, claude_code, codex, opencode, gemini_cli, antigravity, cursor, windsurf, vscode",
             other
         ),
     }

--- a/src/collectors/openrouter.rs
+++ b/src/collectors/openrouter.rs
@@ -1,0 +1,172 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use chrono::Utc;
+use serde::Deserialize;
+
+use super::Collector;
+use crate::costs;
+use crate::models::UsageRecord;
+
+pub struct OpenRouterCollector {
+    api_key: String,
+    client: reqwest::Client,
+}
+
+impl OpenRouterCollector {
+    pub fn new(api_key: String) -> Self {
+        Self {
+            api_key,
+            client: reqwest::Client::new(),
+        }
+    }
+}
+
+/// OpenRouter daily activity response.
+/// GET https://openrouter.ai/api/v1/activity?date_from=YYYY-MM-DD&date_to=YYYY-MM-DD
+/// Returns per-day, per-model aggregated token usage and reported cost in USD.
+#[derive(Debug, Deserialize)]
+struct ActivityResponse {
+    #[serde(default)]
+    data: Vec<ActivityRow>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ActivityRow {
+    #[serde(default)]
+    date: String,
+    #[serde(default)]
+    model: String,
+    #[serde(default)]
+    usage: f64,
+    #[serde(default)]
+    prompt_tokens: i64,
+    #[serde(default)]
+    completion_tokens: i64,
+    #[serde(default)]
+    reasoning_tokens: i64,
+}
+
+#[async_trait]
+impl Collector for OpenRouterCollector {
+    fn name(&self) -> &str {
+        "openrouter"
+    }
+
+    async fn collect(&self) -> Result<Vec<UsageRecord>> {
+        let now = Utc::now();
+        let date_to = now.format("%Y-%m-%d").to_string();
+        let date_from = (now - chrono::Duration::days(30))
+            .format("%Y-%m-%d")
+            .to_string();
+
+        let collected_at = now.to_rfc3339();
+
+        let resp = self
+            .client
+            .get("https://openrouter.ai/api/v1/activity")
+            .bearer_auth(&self.api_key)
+            .query(&[("date_from", &date_from), ("date_to", &date_to)])
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!("OpenRouter activity API error {}: {}", status, body);
+        }
+
+        let activity: ActivityResponse = resp.json().await?;
+        let mut records: Vec<UsageRecord> = Vec::new();
+
+        for row in activity.data {
+            let input_tokens = row.prompt_tokens;
+            // Reasoning tokens bill like output on OpenRouter.
+            let output_tokens = row.completion_tokens + row.reasoning_tokens;
+            if input_tokens == 0 && output_tokens == 0 {
+                continue;
+            }
+
+            let model = if row.model.is_empty() {
+                "unknown".to_string()
+            } else {
+                row.model
+            };
+
+            let cost = if row.usage > 0.0 {
+                Some(row.usage)
+            } else {
+                costs::calculate_cost(&model, "openrouter", input_tokens, output_tokens, 0, 0)
+            };
+
+            let recorded_at = if row.date.is_empty() {
+                now.format("%Y-%m-%d").to_string()
+            } else {
+                row.date
+            };
+
+            records.push(UsageRecord {
+                id: None,
+                provider: "openrouter".to_string(),
+                model,
+                input_tokens,
+                output_tokens,
+                cache_read_tokens: 0,
+                cache_write_tokens: 0,
+                cost_usd: cost,
+                session_id: None,
+                recorded_at,
+                collected_at: collected_at.clone(),
+                metadata: None,
+            });
+        }
+
+        Ok(records)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_activity_response() {
+        let sample = r#"{
+            "data": [
+                {
+                    "date": "2026-04-18",
+                    "model": "anthropic/claude-3.5-sonnet",
+                    "model_permaslug": "anthropic/claude-3.5-sonnet",
+                    "usage": 1.2345,
+                    "byok_usage_inference": 0.0,
+                    "requests": 10,
+                    "prompt_tokens": 12000,
+                    "completion_tokens": 3400,
+                    "reasoning_tokens": 0
+                },
+                {
+                    "date": "2026-04-18",
+                    "model": "deepseek/deepseek-r1",
+                    "usage": 0.0,
+                    "prompt_tokens": 0,
+                    "completion_tokens": 0,
+                    "reasoning_tokens": 0
+                }
+            ]
+        }"#;
+
+        let parsed: ActivityResponse = serde_json::from_str(sample).unwrap();
+        assert_eq!(parsed.data.len(), 2);
+        assert_eq!(parsed.data[0].prompt_tokens, 12000);
+        assert_eq!(parsed.data[0].completion_tokens, 3400);
+        assert!((parsed.data[0].usage - 1.2345).abs() < 1e-9);
+        assert_eq!(parsed.data[0].model, "anthropic/claude-3.5-sonnet");
+    }
+
+    #[test]
+    fn handles_missing_fields() {
+        let sample = r#"{"data": [{"date": "2026-04-18", "model": "x/y"}]}"#;
+        let parsed: ActivityResponse = serde_json::from_str(sample).unwrap();
+        assert_eq!(parsed.data[0].prompt_tokens, 0);
+        assert_eq!(parsed.data[0].usage, 0.0);
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,10 @@ pub struct Config {
     #[serde(default)]
     pub gemini_api_key: Option<String>,
     #[serde(default)]
+    pub openrouter_api_key: Option<String>,
+    #[serde(default)]
+    pub deepseek_api_key: Option<String>,
+    #[serde(default)]
     pub ollama_host: Option<String>,
     #[serde(default = "default_true")]
     pub claude_code_enabled: bool,
@@ -54,6 +58,8 @@ pub fn load_config() -> Result<Config> {
             anthropic_api_key: None,
             openai_api_key: None,
             gemini_api_key: None,
+            openrouter_api_key: None,
+            deepseek_api_key: None,
             ollama_host: None,
             claude_code_enabled: true,
             config_path: path,
@@ -78,6 +84,8 @@ pub fn set_config_value(cfg: &Config, key: &str, value: &str) -> Result<()> {
         "anthropic_api_key" => cfg.anthropic_api_key = Some(value.to_string()),
         "openai_api_key" => cfg.openai_api_key = Some(value.to_string()),
         "gemini_api_key" => cfg.gemini_api_key = Some(value.to_string()),
+        "openrouter_api_key" => cfg.openrouter_api_key = Some(value.to_string()),
+        "deepseek_api_key" => cfg.deepseek_api_key = Some(value.to_string()),
         "ollama_host" => cfg.ollama_host = Some(value.to_string()),
         "claude_code_enabled" => cfg.claude_code_enabled = value.parse()?,
         "db_path" => cfg.db_path = value.to_string(),
@@ -114,6 +122,22 @@ pub fn print_config(cfg: &Config) {
     println!(
         "  gemini:       {}",
         if cfg.gemini_api_key.is_some() {
+            "configured".green()
+        } else {
+            "not set".dimmed()
+        }
+    );
+    println!(
+        "  openrouter:   {}",
+        if cfg.openrouter_api_key.is_some() {
+            "configured".green()
+        } else {
+            "not set".dimmed()
+        }
+    );
+    println!(
+        "  deepseek:     {}",
+        if cfg.deepseek_api_key.is_some() {
             "configured".green()
         } else {
             "not set".dimmed()

--- a/src/costs.rs
+++ b/src/costs.rs
@@ -83,6 +83,7 @@ fn normalize_provider(litellm_provider: &str) -> Option<&'static str> {
         "bedrock" => Some("bedrock"),
         "azure" | "azure_ai" => Some("azure"),
         "deepseek" => Some("deepseek"),
+        "openrouter" => Some("openrouter"),
         "groq" => Some("groq"),
         "together_ai" => Some("together"),
         "fireworks_ai" => Some("fireworks"),
@@ -264,6 +265,14 @@ fn fallback_rates(model: &str) -> Option<FallbackRates> {
     }
     if has_reasoning_token(model, "o1") {
         return Some(rates_no_cache(15.0, 60.0));
+    }
+
+    // DeepSeek — public pricing as of 2025-02. LiteLLM cache overrides when present.
+    if model.contains("deepseek-reasoner") {
+        return Some(rates_no_cache(0.55, 2.19));
+    }
+    if model.contains("deepseek-chat") {
+        return Some(rates_no_cache(0.27, 1.10));
     }
 
     // Gemini family.


### PR DESCRIPTION
## Summary
- Adds `openrouter_api_key` and `deepseek_api_key` to `Config` with serde defaults for backwards compat (#4).
- New OpenRouter collector hits `/api/v1/activity` for the last 30 days, folds reasoning tokens into output, and prefers OpenRouter's reported USD cost with LiteLLM fallback (#20).
- New DeepSeek collector validates the key via `/user/balance` and emits zero records — DeepSeek has no historical usage API; limitation is documented in the file and in `explain_provider_filter` (#21).
- Adds `deepseek-chat` / `deepseek-reasoner` fallback pricing and `openrouter` to `normalize_provider` so both show up in `/models`.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (50 passed)
- [ ] Manual: `llmusage config --set openrouter_api_key=…` then `llmusage sync --provider openrouter` with a real key
- [ ] Manual: `llmusage config --set deepseek_api_key=…` then `llmusage sync --provider deepseek` (expect zero records, clean error on bad key)

Closes #4, #20, #21