### PR TITLE
fix(collectors): ollama heartbeat spam, codex model, opencode metadata

### DIFF
--- a/src/collectors/codex.rs
+++ b/src/collectors/codex.rs
@@ -87,6 +87,7 @@ impl Collector for CodexCollector {
             // Extract session ID and model from session_meta
             let mut session_id = None;
             let mut model_provider = String::from("openai");
+            let mut model_name: Option<String> = None;
 
             // First pass: get session metadata
             for line in content.lines() {
@@ -100,14 +101,28 @@ impl Collector for CodexCollector {
                             {
                                 model_provider = mp.to_string();
                             }
+                            // Codex records the actual model (e.g. "gpt-5",
+                            // "o3", "gpt-4.1") on session_meta. Prefer it so
+                            // costs match LiteLLM pricing and per-model
+                            // breakdowns are meaningful (issue #35).
+                            if let Some(m) = payload
+                                .get("model")
+                                .and_then(|v| v.as_str())
+                                .or_else(|| payload.get("model_id").and_then(|v| v.as_str()))
+                            {
+                                if !m.is_empty() {
+                                    model_name = Some(m.to_string());
+                                }
+                            }
                         }
                     }
                     break;
                 }
             }
 
-            // Codex uses GPT-5 or similar via OpenAI
-            let model = format!("codex-{}", model_provider);
+            // Fall back to the legacy `codex-{provider}` shape only when the
+            // session log doesn't name a model.
+            let model = model_name.unwrap_or_else(|| format!("codex-{}", model_provider));
 
             // Second pass: collect token_count entries.
             // Codex occasionally re-emits the exact same event line (e.g. on session

--- a/src/collectors/ollama.rs
+++ b/src/collectors/ollama.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use async_trait::async_trait;
-use chrono::Utc;
-use serde::Deserialize;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use super::Collector;
 use crate::models::UsageRecord;
@@ -20,17 +19,9 @@ impl OllamaCollector {
     }
 }
 
-#[derive(Debug, Deserialize)]
-struct OllamaRunningResponse {
-    models: Vec<OllamaRunningModel>,
-}
-
-#[derive(Debug, Deserialize)]
-struct OllamaRunningModel {
-    name: String,
-    #[serde(default)]
-    size: i64,
-}
+// Print the limitations note at most once per process so repeated `sync`
+// invocations from a long-running watcher don't spam the user.
+static WARNED: AtomicBool = AtomicBool::new(false);
 
 #[async_trait]
 impl Collector for OllamaCollector {
@@ -38,20 +29,26 @@ impl Collector for OllamaCollector {
         "ollama"
     }
 
+    /// Ollama does not persist per-request token usage anywhere we can read
+    /// after the fact. Investigation summary (issue #17):
+    ///
+    ///   * `/api/ps` and `/api/tags` only describe loaded/available models.
+    ///     They expose no historical token counts.
+    ///   * `/api/generate` and `/api/chat` responses include `eval_count` and
+    ///     `prompt_eval_count`, but only for the in-flight request. Capturing
+    ///     them requires sitting in the request path (proxy or client wrapper).
+    ///   * Server logs (`~/.ollama/logs/server.log`, journalctl on Linux) at
+    ///     `OLLAMA_LOG_LEVEL=info` log requests but not token counts. Bumping
+    ///     to `debug` is noisy and still does not expose `eval_count` in a
+    ///     structured form across versions.
+    ///   * Ollama has no hook/plugin system today.
+    ///
+    /// Conclusion: the only viable approaches are out-of-process — run a
+    /// logging proxy in front of Ollama (see README) or have the calling
+    /// client emit usage records directly. Until one of those is wired up,
+    /// this collector confirms reachability and emits zero records rather than
+    /// inserting useless 0-token heartbeat rows (issue #27).
     async fn collect(&self) -> Result<Vec<UsageRecord>> {
-        // Ollama doesn't persist usage logs by default.
-        // What we CAN do:
-        //   1. List running models via /api/ps
-        //   2. List available models via /api/tags
-        //
-        // For actual token tracking, you'd need to either:
-        //   - Run a reverse proxy that logs request/response metadata
-        //   - Patch Ollama to write usage to a file
-        //   - Use the /api/generate response metadata (eval_count, prompt_eval_count)
-        //
-        // This collector checks if Ollama is reachable and reports available models.
-        // Real usage tracking requires the proxy approach.
-
         let resp = self
             .client
             .get(format!("{}/api/ps", self.host))
@@ -60,36 +57,15 @@ impl Collector for OllamaCollector {
 
         match resp {
             Ok(r) if r.status().is_success() => {
-                let running: OllamaRunningResponse = r.json().await?;
-                let collected_at = Utc::now().to_rfc3339();
-                let now = Utc::now().format("%Y-%m-%d").to_string();
-
-                // Report running models as a heartbeat record (0 tokens)
-                // Actual token counts require proxy integration
-                let records: Vec<UsageRecord> = running
-                    .models
-                    .into_iter()
-                    .map(|m| UsageRecord {
-                        id: None,
-                        provider: "ollama".to_string(),
-                        model: m.name,
-                        input_tokens: 0,
-                        output_tokens: 0,
-                        cache_read_tokens: 0,
-                        cache_write_tokens: 0,
-                        cost_usd: Some(0.0),
-                        session_id: None,
-                        recorded_at: now.clone(),
-                        collected_at: collected_at.clone(),
-                        metadata: Some(format!("{{\"size\": {}}}", m.size)),
-                    })
-                    .collect();
-
-                if records.is_empty() {
-                    Ok(vec![]) // Ollama running but no models loaded
-                } else {
-                    Ok(records)
+                if !WARNED.swap(true, Ordering::Relaxed) {
+                    eprintln!(
+                        "ollama: reachable at {} but token usage is not tracked. \
+                         Ollama does not persist per-request usage; run a logging \
+                         proxy in front of it to capture token counts.",
+                        self.host
+                    );
                 }
+                Ok(vec![])
             }
             Ok(r) => {
                 anyhow::bail!("Ollama returned status {}", r.status());

--- a/src/collectors/opencode.rs
+++ b/src/collectors/opencode.rs
@@ -152,7 +152,7 @@ impl Collector for OpenCodeCollector {
                     collected_at: collected_at.clone(),
                     metadata: msg
                         .provider_id
-                        .map(|p| format!("{{\"provider\": \"{}\"}}", p)),
+                        .map(|p| serde_json::json!({ "provider": p }).to_string()),
                 });
             }
         }

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Result};
 use rusqlite::Connection;
 
-const LATEST_SCHEMA_VERSION: i64 = 2;
+const LATEST_SCHEMA_VERSION: i64 = 3;
 
 const CREATE_USAGE_RECORDS_TABLE_SQL: &str = "
     CREATE TABLE IF NOT EXISTS usage_records (
@@ -97,6 +97,7 @@ fn migrate(conn: &Connection, from: i64, to: i64) -> Result<()> {
     while version < to {
         match version {
             1 => migrate_v1_to_v2(&tx)?,
+            2 => migrate_v2_to_v3(&tx)?,
             _ => bail!("No migration path from schema version {}", version),
         }
         version += 1;
@@ -109,6 +110,22 @@ fn migrate(conn: &Connection, from: i64, to: i64) -> Result<()> {
 
 fn migrate_v1_to_v2(conn: &Connection) -> Result<()> {
     conn.execute_batch(CREATE_INDEXES_SQL)?;
+    Ok(())
+}
+
+// Drop legacy 0-token Ollama heartbeat rows (issues #17/#27). Other providers
+// (e.g. cursor) emit intentional zero-token sentinel records, so the cleanup
+// is scoped to provider = 'ollama'.
+fn migrate_v2_to_v3(conn: &Connection) -> Result<()> {
+    conn.execute(
+        "DELETE FROM usage_records
+         WHERE provider = 'ollama'
+           AND input_tokens = 0
+           AND output_tokens = 0
+           AND cache_read_tokens = 0
+           AND cache_write_tokens = 0",
+        [],
+    )?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- **#17 / #27** — Ollama collector no longer inserts 0-token heartbeat rows. It confirms reachability and emits a one-time warning explaining that usage tracking needs an out-of-process proxy (Ollama has no viable post-hoc source for token counts). Schema v3 migration deletes legacy `provider='ollama'` zero-token rows, scoped so cursor's intentional zero-token sentinels are preserved.
- **#35** — Codex collector reads the actual model (`model` / `model_id`) from `session_meta` instead of hardcoding `codex-{provider}`, so per-model breakdowns and LiteLLM cost lookups work. Falls back to the old shape only when no model name is present.
- **#37** — OpenCode metadata JSON is now built via `serde_json::json!` instead of `format!`, eliminating the latent corruption risk when `provider_id` contains quotes/backslashes.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (54 passed)