### PR TITLE
feat(cli): validate --provider via ValueEnum; extend pricing for deepseek/openrouter

### DIFF
--- a/src/collectors/mod.rs
+++ b/src/collectors/mod.rs
@@ -17,6 +17,52 @@ use std::path::PathBuf;
 use crate::config::Config;
 use crate::models::UsageRecord;
 
+/// Known providers. The single source of truth for `--provider` flag values.
+///
+/// When adding a new collector in `get_collectors`, add the matching variant
+/// here — the compiler will not force this, but `explain_provider_filter`
+/// exhaustively matches on the canonical name string so behavior stays in sync.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, clap::ValueEnum)]
+#[value(rename_all = "snake_case")]
+pub enum Provider {
+    Anthropic,
+    Openai,
+    Gemini,
+    Openrouter,
+    Deepseek,
+    Ollama,
+    ClaudeCode,
+    Codex,
+    Opencode,
+    #[value(alias = "gemini-cli", alias = "antigravity")]
+    GeminiCli,
+    Cursor,
+    Windsurf,
+    #[value(alias = "vscode-copilot-chat")]
+    Vscode,
+}
+
+impl Provider {
+    /// Canonical snake_case name used internally and stored in the DB.
+    pub fn canonical_name(self) -> &'static str {
+        match self {
+            Provider::Anthropic => "anthropic",
+            Provider::Openai => "openai",
+            Provider::Gemini => "gemini",
+            Provider::Openrouter => "openrouter",
+            Provider::Deepseek => "deepseek",
+            Provider::Ollama => "ollama",
+            Provider::ClaudeCode => "claude_code",
+            Provider::Codex => "codex",
+            Provider::Opencode => "opencode",
+            Provider::GeminiCli => "gemini_cli",
+            Provider::Cursor => "cursor",
+            Provider::Windsurf => "windsurf",
+            Provider::Vscode => "vscode",
+        }
+    }
+}
+
 #[async_trait]
 pub trait Collector: Send + Sync {
     fn name(&self) -> &str;

--- a/src/costs.rs
+++ b/src/costs.rs
@@ -154,11 +154,22 @@ pub fn calculate_cost(
     // Try loading from LiteLLM cache
     if let Some(entries) = load_cached_pricing() {
         // Try exact match first, then prefix match
-        let entry = entries.get(model).or_else(|| {
-            // Try provider/model format (e.g., "anthropic/claude-sonnet-4-20250514")
-            let prefixed = format!("{}/{}", provider, model);
-            entries.get(&prefixed)
-        });
+        let prefixed = format!("{}/{}", provider, model);
+        let entry = entries
+            .get(model)
+            .or_else(|| entries.get(&prefixed))
+            .or_else(|| {
+                // OpenRouter models use upstream names like "anthropic/claude-3.5-sonnet".
+                // LiteLLM typically keys these as "openrouter/anthropic/claude-3.5-sonnet",
+                // but when that misses we also try the bare upstream model after the last '/'.
+                if provider == "openrouter" {
+                    model
+                        .rsplit_once('/')
+                        .and_then(|(_, bare)| entries.get(bare))
+                } else {
+                    None
+                }
+            });
 
         if let Some(entry) = entry {
             if let (Some(input_cpt), Some(output_cpt)) =
@@ -378,6 +389,8 @@ fn get_fallback_pricing(provider_filter: Option<&str>) -> Vec<ModelPricing> {
         mp("openai", "o3-mini", 1.10, 4.40, None, None),
         mp("gemini", "gemini-2.5-pro", 1.25, 10.0, None, None),
         mp("gemini", "gemini-2.5-flash", 0.15, 0.60, None, None),
+        mp("deepseek", "deepseek-chat", 0.27, 1.10, None, None),
+        mp("deepseek", "deepseek-reasoner", 0.55, 2.19, None, None),
         mp("ollama", "local-models", 0.0, 0.0, None, None),
     ];
 
@@ -478,5 +491,32 @@ mod fallback_tests {
     fn openai_no_cache_rates_ignore_cache_tokens() {
         let cost = calculate_cost_fallback("gpt-4o", "openai", 0, 0, 1_000_000, 1_000_000).unwrap();
         assert_eq!(cost, 0.0);
+    }
+
+    #[test]
+    fn deepseek_fallback_pricing_included() {
+        let models = get_fallback_pricing(Some("deepseek"));
+        let names: Vec<&str> = models.iter().map(|m| m.model.as_str()).collect();
+        assert!(names.contains(&"deepseek-chat"));
+        assert!(names.contains(&"deepseek-reasoner"));
+    }
+
+    #[test]
+    fn deepseek_reasoner_fallback_cost() {
+        let cost =
+            calculate_cost_fallback("deepseek-reasoner", "deepseek", 1_000_000, 1_000_000, 0, 0)
+                .unwrap();
+        // 0.55 input + 2.19 output per MTok
+        assert!((cost - 2.74).abs() < 1e-9, "got {cost}");
+    }
+
+    #[test]
+    fn openrouter_normalizes_to_openrouter() {
+        assert_eq!(normalize_provider("openrouter"), Some("openrouter"));
+    }
+
+    #[test]
+    fn deepseek_normalizes_to_deepseek() {
+        assert_eq!(normalize_provider("deepseek"), Some("deepseek"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,8 @@ mod models;
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 
+use crate::collectors::Provider;
+
 #[derive(Parser)]
 #[command(name = "llmusage")]
 #[command(about = "Track token usage and costs across AI providers")]
@@ -23,7 +25,7 @@ enum Commands {
     Sync {
         /// Specific provider to sync (default: all configured)
         #[arg(short, long)]
-        provider: Option<String>,
+        provider: Option<Provider>,
     },
     /// Show usage summary
     Summary {
@@ -32,7 +34,7 @@ enum Commands {
         days: u32,
         /// Filter by provider
         #[arg(short = 'P', long)]
-        provider: Option<String>,
+        provider: Option<Provider>,
         /// Filter by model
         #[arg(short, long)]
         model: Option<String>,
@@ -44,7 +46,7 @@ enum Commands {
         days: u32,
         /// Filter by provider
         #[arg(short = 'P', long)]
-        provider: Option<String>,
+        provider: Option<Provider>,
         /// Output as JSON
         #[arg(long)]
         json: bool,
@@ -59,7 +61,7 @@ enum Commands {
         weeks: u32,
         /// Filter by provider
         #[arg(short = 'P', long)]
-        provider: Option<String>,
+        provider: Option<Provider>,
         /// Output as JSON
         #[arg(long)]
         json: bool,
@@ -74,7 +76,7 @@ enum Commands {
         months: u32,
         /// Filter by provider
         #[arg(short = 'P', long)]
-        provider: Option<String>,
+        provider: Option<Provider>,
         /// Output as JSON
         #[arg(long)]
         json: bool,
@@ -89,7 +91,7 @@ enum Commands {
         model: Option<String>,
         /// Filter by provider
         #[arg(short = 'P', long)]
-        provider: Option<String>,
+        provider: Option<Provider>,
         /// Start date (YYYY-MM-DD)
         #[arg(short, long)]
         since: Option<String>,
@@ -104,7 +106,7 @@ enum Commands {
     Models {
         /// Filter by provider
         #[arg(short = 'P', long)]
-        provider: Option<String>,
+        provider: Option<Provider>,
     },
     /// Manage configuration
     Config {
@@ -156,7 +158,7 @@ async fn main() -> Result<()> {
 
     match cli.command {
         Commands::Sync { provider } => {
-            cmd_sync(&cfg, &db, canonical_provider_filter(provider.as_deref())).await?;
+            cmd_sync(&cfg, &db, provider.map(Provider::canonical_name)).await?;
         }
         Commands::Summary {
             days,
@@ -166,7 +168,7 @@ async fn main() -> Result<()> {
             cmd_summary(
                 &db,
                 days,
-                canonical_provider_filter(provider.as_deref()),
+                provider.map(Provider::canonical_name),
                 model.as_deref(),
             )?;
         }
@@ -176,13 +178,7 @@ async fn main() -> Result<()> {
             json,
             all,
         } => {
-            cmd_daily(
-                &db,
-                days,
-                canonical_provider_filter(provider.as_deref()),
-                json,
-                all,
-            )?;
+            cmd_daily(&db, days, provider.map(Provider::canonical_name), json, all)?;
         }
         Commands::Weekly {
             weeks,
@@ -193,7 +189,7 @@ async fn main() -> Result<()> {
             cmd_weekly(
                 &db,
                 weeks,
-                canonical_provider_filter(provider.as_deref()),
+                provider.map(Provider::canonical_name),
                 json,
                 all,
             )?;
@@ -207,7 +203,7 @@ async fn main() -> Result<()> {
             cmd_monthly(
                 &db,
                 months,
-                canonical_provider_filter(provider.as_deref()),
+                provider.map(Provider::canonical_name),
                 json,
                 all,
             )?;
@@ -222,14 +218,14 @@ async fn main() -> Result<()> {
             cmd_detail(
                 &db,
                 model.as_deref(),
-                canonical_provider_filter(provider.as_deref()),
+                provider.map(Provider::canonical_name),
                 since.as_deref(),
                 until.as_deref(),
                 limit,
             )?;
         }
         Commands::Models { provider } => {
-            cmd_models(canonical_provider_filter(provider.as_deref()))?;
+            cmd_models(provider.map(Provider::canonical_name))?;
         }
         Commands::UpdatePricing => {
             cmd_update_pricing().await?;
@@ -426,10 +422,6 @@ fn cmd_config(cfg: &config::Config, set: Option<&str>, _list: bool) -> Result<()
         }
     }
     Ok(())
-}
-
-fn canonical_provider_filter(provider: Option<&str>) -> Option<&str> {
-    provider.map(collectors::canonical_provider_name)
 }
 
 async fn cmd_update_pricing() -> Result<()> {


### PR DESCRIPTION
## Summary
- Closes #25: `--provider` flag is now a clap `ValueEnum` (`Provider`) on all 7 commands, yielding `[possible values: ...]` listings, "did you mean?" suggestions on typos, and shell-completion metadata. Aliases preserved (`gemini-cli`/`antigravity` → `gemini_cli`, `vscode-copilot-chat` → `vscode`).
- Closes #28: `normalize_provider()` already mapped `openrouter`/`deepseek`; added `deepseek-chat` and `deepseek-reasoner` to `get_fallback_pricing`, and added an OpenRouter-specific last-resort LiteLLM lookup that strips the upstream provider prefix (`anthropic/claude-3.5-sonnet` → `claude-3.5-sonnet`) for cases where the cache doesn't have the `openrouter/...` key. OpenRouter collector already passes API-reported cost through when non-zero.
- Also updated three `config.rs` unit tests to include the new `openrouter_api_key` / `deepseek_api_key` fields (previously unbuildable after the recent Config extension).

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets`
- [x] `cargo test` (58 passed)
- [x] `llmusage sync --provider anthropi` shows `tip: a similar value exists: 'anthropic'`
- [x] `llmusage models --provider gemini-cli` / `--provider antigravity` resolve via alias
- [x] `llmusage models --provider deepseek` lists deepseek models with pricing

🤖 Generated with [Claude Code](https://claude.com/claude-code)