### PR TITLE
feat: batch fix issues #40, #41, #47, #51, #53

### DIFF
--- a/src/collectors/anthropic.rs
+++ b/src/collectors/anthropic.rs
@@ -96,7 +96,7 @@ impl Collector for AnthropicCollector {
                 .client
                 .get("https://api.anthropic.com/v1/organizations/usage_report/messages")
                 .header("x-api-key", &self.api_key)
-                .header("anthropic-version", "2023-06-01")
+                .header("anthropic-version", "2024-10-22")
                 .query(&query)
                 .send()
                 .await?;

--- a/src/collectors/mod.rs
+++ b/src/collectors/mod.rs
@@ -123,7 +123,7 @@ pub fn get_collectors(
         }
     }
 
-    if should_include("ollama") {
+    if should_include("ollama") && cfg.ollama_enabled {
         let host = cfg
             .ollama_host
             .clone()
@@ -300,7 +300,14 @@ pub fn explain_provider_filter(cfg: &Config, provider_filter: &str) -> String {
                     .to_string()
             }
         }
-        "ollama" => "Provider 'ollama' is supported, but no collector could be activated.".to_string(),
+        "ollama" => {
+            if cfg.ollama_enabled {
+                "Provider 'ollama' is enabled, but no collector could be activated.".to_string()
+            } else {
+                "Provider 'ollama' is disabled. Run `llmusage config --set ollama_enabled=true` to include it in sync."
+                    .to_string()
+            }
+        }
         "claude_code" => {
             if cfg.claude_code_enabled {
                 "Provider 'claude_code' is enabled, but no local session logs were found."

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,8 @@ pub struct Config {
     pub deepseek_api_key: Option<String>,
     #[serde(default)]
     pub ollama_host: Option<String>,
+    #[serde(default)]
+    pub ollama_enabled: bool,
     #[serde(default = "default_true")]
     pub claude_code_enabled: bool,
     #[serde(skip)]
@@ -61,6 +63,7 @@ pub fn load_config() -> Result<Config> {
             openrouter_api_key: None,
             deepseek_api_key: None,
             ollama_host: None,
+            ollama_enabled: false,
             claude_code_enabled: true,
             config_path: path.clone(),
         }
@@ -96,6 +99,7 @@ pub fn set_config_value(cfg: &Config, key: &str, value: &str) -> Result<()> {
         "openrouter_api_key" => cfg.openrouter_api_key = Some(value.to_string()),
         "deepseek_api_key" => cfg.deepseek_api_key = Some(value.to_string()),
         "ollama_host" => cfg.ollama_host = Some(value.to_string()),
+        "ollama_enabled" => cfg.ollama_enabled = value.parse()?,
         "claude_code_enabled" => cfg.claude_code_enabled = value.parse()?,
         "db_path" => cfg.db_path = value.to_string(),
         _ => anyhow::bail!("Unknown config key: {}", key),
@@ -144,7 +148,9 @@ pub fn print_config(cfg: &Config) {
     );
     println!(
         "  openrouter:   {}",
-        if cfg.openrouter_api_key.is_some() {
+        if env_var_present("OPENROUTER_API_KEY") {
+            "configured (env)".green()
+        } else if cfg.openrouter_api_key.is_some() {
             "configured".green()
         } else {
             "not set".dimmed()
@@ -152,24 +158,26 @@ pub fn print_config(cfg: &Config) {
     );
     println!(
         "  deepseek:     {}",
-        if cfg.deepseek_api_key.is_some() {
+        if env_var_present("DEEPSEEK_API_KEY") {
+            "configured (env)".green()
+        } else if cfg.deepseek_api_key.is_some() {
             "configured".green()
         } else {
             "not set".dimmed()
         }
     );
+    let ollama_host_display = cfg
+        .ollama_host
+        .clone()
+        .unwrap_or_else(|| "http://localhost:11434".to_string());
     println!(
         "  ollama:       {}",
-        if env_var_present("OLLAMA_HOST") {
-            "configured (env)".green()
-        } else if cfg.ollama_host.is_some() {
-            cfg.ollama_host
-                .as_deref()
-                .unwrap_or_default()
-                .to_string()
-                .green()
+        if !cfg.ollama_enabled {
+            "disabled (set ollama_enabled=true to include in sync)".dimmed()
+        } else if env_var_present("OLLAMA_HOST") {
+            format!("enabled (env: {})", ollama_host_display).green()
         } else {
-            "not set (default: http://localhost:11434)".dimmed()
+            format!("enabled ({})", ollama_host_display).green()
         }
     );
     println!(
@@ -191,6 +199,12 @@ fn apply_env_overrides(cfg: &mut Config) {
     }
     if let Some(value) = env_var_value("GEMINI_API_KEY") {
         cfg.gemini_api_key = Some(value);
+    }
+    if let Some(value) = env_var_value("OPENROUTER_API_KEY") {
+        cfg.openrouter_api_key = Some(value);
+    }
+    if let Some(value) = env_var_value("DEEPSEEK_API_KEY") {
+        cfg.deepseek_api_key = Some(value);
     }
     if let Some(value) = env_var_value("OLLAMA_HOST") {
         cfg.ollama_host = Some(value);
@@ -276,6 +290,7 @@ mod tests {
             openrouter_api_key: None,
             deepseek_api_key: None,
             ollama_host: Some("http://file-host".to_string()),
+            ollama_enabled: false,
             claude_code_enabled: true,
             config_path: PathBuf::from("config.toml"),
         };
@@ -300,6 +315,7 @@ mod tests {
             openrouter_api_key: None,
             deepseek_api_key: None,
             ollama_host: None,
+            ollama_enabled: false,
             claude_code_enabled: true,
             config_path: PathBuf::from("config.toml"),
         };
@@ -323,6 +339,7 @@ mod tests {
             openrouter_api_key: None,
             deepseek_api_key: None,
             ollama_host: None,
+            ollama_enabled: false,
             claude_code_enabled: true,
             config_path: path.clone(),
         };

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -38,24 +38,33 @@ impl Database {
         &self,
         days: u32,
         provider: Option<&str>,
+        model: Option<&str>,
+        since: Option<&str>,
+        until: Option<&str>,
     ) -> Result<Vec<crate::models::DailyRow>> {
-        queries::query_daily(&self.conn, days, provider)
+        queries::query_daily(&self.conn, days, provider, model, since, until)
     }
 
     pub fn query_weekly(
         &self,
         weeks: u32,
         provider: Option<&str>,
+        model: Option<&str>,
+        since: Option<&str>,
+        until: Option<&str>,
     ) -> Result<Vec<crate::models::DailyRow>> {
-        queries::query_weekly(&self.conn, weeks, provider)
+        queries::query_weekly(&self.conn, weeks, provider, model, since, until)
     }
 
     pub fn query_monthly(
         &self,
         months: u32,
         provider: Option<&str>,
+        model: Option<&str>,
+        since: Option<&str>,
+        until: Option<&str>,
     ) -> Result<Vec<crate::models::DailyRow>> {
-        queries::query_monthly(&self.conn, months, provider)
+        queries::query_monthly(&self.conn, months, provider, model, since, until)
     }
 
     pub fn query_detail(

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -151,12 +151,22 @@ pub fn query_detail(
     Ok(results)
 }
 
-pub fn query_daily(conn: &Connection, days: u32, provider: Option<&str>) -> Result<Vec<DailyRow>> {
+pub fn query_daily(
+    conn: &Connection,
+    days: u32,
+    provider: Option<&str>,
+    model: Option<&str>,
+    since: Option<&str>,
+    until: Option<&str>,
+) -> Result<Vec<DailyRow>> {
     query_grouped(
         conn,
         "DATE(recorded_at)",
         &format!("-{} days", days),
         provider,
+        model,
+        since,
+        until,
     )
 }
 
@@ -164,6 +174,9 @@ pub fn query_weekly(
     conn: &Connection,
     weeks: u32,
     provider: Option<&str>,
+    model: Option<&str>,
+    since: Option<&str>,
+    until: Option<&str>,
 ) -> Result<Vec<DailyRow>> {
     // SQLite's `%V`/`%G` strftime modifiers were added in SQLite 3.46 (May 2024).
     // The bundled build in `rusqlite = 0.31` ships SQLite 3.45, where those
@@ -175,6 +188,9 @@ pub fn query_weekly(
         "DATE(recorded_at)",
         &format!("-{} days", weeks * 7),
         provider,
+        model,
+        since,
+        until,
     )?;
     Ok(rebucket_daily_by_iso_week(daily))
 }
@@ -236,12 +252,18 @@ pub fn query_monthly(
     conn: &Connection,
     months: u32,
     provider: Option<&str>,
+    model: Option<&str>,
+    since: Option<&str>,
+    until: Option<&str>,
 ) -> Result<Vec<DailyRow>> {
     query_grouped(
         conn,
         "strftime('%Y-%m', recorded_at)",
         &format!("-{} months", months),
         provider,
+        model,
+        since,
+        until,
     )
 }
 
@@ -250,6 +272,9 @@ fn query_grouped(
     group_expr: &str,
     lookback: &str,
     provider: Option<&str>,
+    model: Option<&str>,
+    since: Option<&str>,
+    until: Option<&str>,
 ) -> Result<Vec<DailyRow>> {
     let mut sql = format!(
         "SELECT {group_expr} as period, provider, model,
@@ -257,15 +282,43 @@ fn query_grouped(
          SUM(output_tokens) as total_output,
          COALESCE(SUM(cost_usd), 0) as total_cost
          FROM usage_records
-         WHERE recorded_at >= datetime('now', ?1)"
+         WHERE 1=1"
     );
 
-    let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> =
-        vec![Box::new(lookback.to_string())];
+    let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+
+    // Explicit --since overrides the rolling lookback; otherwise apply the
+    // lookback window computed from --days/--weeks/--months.
+    if let Some(s) = since {
+        sql.push_str(&format!(" AND recorded_at >= ?{}", param_values.len() + 1));
+        param_values.push(Box::new(s.to_string()));
+    } else {
+        sql.push_str(&format!(
+            " AND recorded_at >= datetime('now', ?{})",
+            param_values.len() + 1
+        ));
+        param_values.push(Box::new(lookback.to_string()));
+    }
+
+    if let Some(u) = until {
+        sql.push_str(&format!(" AND recorded_at <= ?{}", param_values.len() + 1));
+        let until_val =
+            if u.len() == 10 && u.chars().nth(4) == Some('-') && u.chars().nth(7) == Some('-') {
+                format!("{}T23:59:59", u)
+            } else {
+                u.to_string()
+            };
+        param_values.push(Box::new(until_val));
+    }
 
     if let Some(p) = provider {
         sql.push_str(&format!(" AND provider = ?{}", param_values.len() + 1));
         param_values.push(Box::new(p.to_string()));
+    }
+
+    if let Some(m) = model {
+        sql.push_str(&format!(" AND model LIKE ?{}", param_values.len() + 1));
+        param_values.push(Box::new(format!("%{}%", m)));
     }
 
     sql.push_str(

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,15 @@ enum Commands {
         /// Filter by provider
         #[arg(short = 'P', long)]
         provider: Option<Provider>,
+        /// Filter by model (substring match)
+        #[arg(short, long)]
+        model: Option<String>,
+        /// Start date (YYYY-MM-DD) — overrides --days
+        #[arg(long)]
+        since: Option<String>,
+        /// End date (YYYY-MM-DD)
+        #[arg(long)]
+        until: Option<String>,
         /// Output as JSON
         #[arg(long)]
         json: bool,
@@ -62,6 +71,15 @@ enum Commands {
         /// Filter by provider
         #[arg(short = 'P', long)]
         provider: Option<Provider>,
+        /// Filter by model (substring match)
+        #[arg(short, long)]
+        model: Option<String>,
+        /// Start date (YYYY-MM-DD) — overrides --weeks
+        #[arg(long)]
+        since: Option<String>,
+        /// End date (YYYY-MM-DD)
+        #[arg(long)]
+        until: Option<String>,
         /// Output as JSON
         #[arg(long)]
         json: bool,
@@ -77,6 +95,15 @@ enum Commands {
         /// Filter by provider
         #[arg(short = 'P', long)]
         provider: Option<Provider>,
+        /// Filter by model (substring match)
+        #[arg(short, long)]
+        model: Option<String>,
+        /// Start date (YYYY-MM-DD) — overrides --months
+        #[arg(long)]
+        since: Option<String>,
+        /// End date (YYYY-MM-DD)
+        #[arg(long)]
+        until: Option<String>,
         /// Output as JSON
         #[arg(long)]
         json: bool,
@@ -175,14 +202,29 @@ async fn main() -> Result<()> {
         Commands::Daily {
             days,
             provider,
+            model,
+            since,
+            until,
             json,
             all,
         } => {
-            cmd_daily(&db, days, provider.map(Provider::canonical_name), json, all)?;
+            cmd_daily(
+                &db,
+                days,
+                provider.map(Provider::canonical_name),
+                model.as_deref(),
+                since.as_deref(),
+                until.as_deref(),
+                json,
+                all,
+            )?;
         }
         Commands::Weekly {
             weeks,
             provider,
+            model,
+            since,
+            until,
             json,
             all,
         } => {
@@ -190,6 +232,9 @@ async fn main() -> Result<()> {
                 &db,
                 weeks,
                 provider.map(Provider::canonical_name),
+                model.as_deref(),
+                since.as_deref(),
+                until.as_deref(),
                 json,
                 all,
             )?;
@@ -197,6 +242,9 @@ async fn main() -> Result<()> {
         Commands::Monthly {
             months,
             provider,
+            model,
+            since,
+            until,
             json,
             all,
         } => {
@@ -204,6 +252,9 @@ async fn main() -> Result<()> {
                 &db,
                 months,
                 provider.map(Provider::canonical_name),
+                model.as_deref(),
+                since.as_deref(),
+                until.as_deref(),
                 json,
                 all,
             )?;
@@ -314,14 +365,18 @@ fn cmd_summary(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn cmd_daily(
     db: &db::Database,
     days: u32,
     provider: Option<&str>,
+    model: Option<&str>,
+    since: Option<&str>,
+    until: Option<&str>,
     json: bool,
     show_all: bool,
 ) -> Result<()> {
-    let rows = db.query_daily(days, provider)?;
+    let rows = db.query_daily(days, provider, model, since, until)?;
     if json {
         let filtered = display::filter_daily_rows(&rows, show_all);
         println!("{}", serde_json::to_string_pretty(&filtered)?);
@@ -331,14 +386,18 @@ fn cmd_daily(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn cmd_weekly(
     db: &db::Database,
     weeks: u32,
     provider: Option<&str>,
+    model: Option<&str>,
+    since: Option<&str>,
+    until: Option<&str>,
     json: bool,
     show_all: bool,
 ) -> Result<()> {
-    let rows = db.query_weekly(weeks, provider)?;
+    let rows = db.query_weekly(weeks, provider, model, since, until)?;
     if json {
         let filtered = display::filter_daily_rows(&rows, show_all);
         println!("{}", serde_json::to_string_pretty(&filtered)?);
@@ -348,14 +407,18 @@ fn cmd_weekly(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn cmd_monthly(
     db: &db::Database,
     months: u32,
     provider: Option<&str>,
+    model: Option<&str>,
+    since: Option<&str>,
+    until: Option<&str>,
     json: bool,
     show_all: bool,
 ) -> Result<()> {
-    let rows = db.query_monthly(months, provider)?;
+    let rows = db.query_monthly(months, provider, model, since, until)?;
     if json {
         let filtered = display::filter_daily_rows(&rows, show_all);
         println!("{}", serde_json::to_string_pretty(&filtered)?);


### PR DESCRIPTION
## Summary

Addresses five open issues in one batched PR:

- **#40**: Add `--since`/`--until` date filters to `daily`/`weekly`/`monthly` commands. When `--since` is passed it overrides the rolling lookback window; `--until` accepts bare `YYYY-MM-DD` and is expanded to end-of-day.
- **#41**: Add `--model`/`-m` filter (substring match via `LIKE %m%`) to `daily`/`weekly`/`monthly` commands, threaded through `query_grouped`.
- **#47**: Ollama collector now requires explicit `ollama_enabled=true` in config; it is no longer included in every sync. `explain_provider_filter` and `print_config` guide users to enable it.
- **#51**: Bump `anthropic-version` header from `2023-06-01` to `2024-10-22` in the Anthropic usage collector.
- **#53**: Add `OPENROUTER_API_KEY` and `DEEPSEEK_API_KEY` env-var overrides (the other providers already supported env vars). `config --list` now labels them `configured (env)` when present.

## Test plan

- [x] `cargo build`
- [x] `cargo test` — 58 passed
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] Manual: `llmusage daily --since 2026-03-01 --until 2026-03-31 -m claude-sonnet-4`
- [x] Manual: `llmusage config --list` shows env-backed keys and ollama disabled state
- [x] Manual: `llmusage sync` no longer errors on ollama for users who haven't opted in

Closes #40, #41, #47, #51, #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)