### PR TITLE
feat(opencode): incremental sync + close ollama issues #27/#47

### DIFF
--- a/src/collectors/mod.rs
+++ b/src/collectors/mod.rs
@@ -86,6 +86,7 @@ pub enum LocalCollectorState {
 pub fn get_collectors(
     cfg: &Config,
     provider_filter: Option<&str>,
+    db: Option<&crate::db::Database>,
 ) -> Result<Vec<Box<dyn Collector>>> {
     let provider_filter = provider_filter.map(canonical_provider_name);
     let mut collectors: Vec<Box<dyn Collector>> = Vec::new();
@@ -146,7 +147,10 @@ pub fn get_collectors(
     if should_include("opencode") {
         let db_path = opencode_db_path();
         if db_path.exists() {
-            collectors.push(Box::new(opencode::OpenCodeCollector::new()));
+            let watermark = db.and_then(|d| d.max_recorded_at_millis("opencode").ok().flatten());
+            collectors.push(Box::new(
+                opencode::OpenCodeCollector::new().with_watermark(watermark),
+            ));
         }
     }
 

--- a/src/collectors/opencode.rs
+++ b/src/collectors/opencode.rs
@@ -9,6 +9,10 @@ use crate::models::UsageRecord;
 
 pub struct OpenCodeCollector {
     db_path: PathBuf,
+    /// Only ingest messages with `time_created` strictly greater than this
+    /// epoch-millisecond watermark. `None` means a full scan (first sync or
+    /// if the watermark cannot be determined). Issue #39.
+    since_ms: Option<i64>,
 }
 
 impl Default for OpenCodeCollector {
@@ -27,7 +31,19 @@ impl OpenCodeCollector {
                 .join("share")
                 .join("opencode")
                 .join("opencode.db"),
+            since_ms: None,
         }
+    }
+
+    pub fn with_watermark(mut self, since_ms: Option<i64>) -> Self {
+        self.since_ms = since_ms;
+        self
+    }
+
+    #[cfg(test)]
+    fn with_db_path(mut self, path: PathBuf) -> Self {
+        self.db_path = path;
+        self
     }
 }
 
@@ -92,23 +108,43 @@ impl Collector for OpenCodeCollector {
         let collected_at = Utc::now().to_rfc3339();
         let mut records = Vec::new();
 
-        let mut stmt = conn.prepare(
-            "SELECT m.data, m.session_id, m.time_created
-             FROM message m
-             ORDER BY m.time_created ASC",
-        )?;
+        // Incremental sync: skip messages we've already ingested. The watermark
+        // is the max recorded_at stored in the llmusage DB for provider='opencode',
+        // converted to epoch ms. recorded_at is second-precision so a message
+        // that lands within the same second as the watermark will be re-read
+        // and filtered by INSERT OR IGNORE downstream — bounded and fine.
+        let fetched: Vec<(String, String, i64)> = {
+            let map_row = |row: &rusqlite::Row<'_>| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, i64>(2)?,
+                ))
+            };
+            match self.since_ms {
+                Some(since) => {
+                    let mut stmt = conn.prepare(
+                        "SELECT m.data, m.session_id, m.time_created
+                         FROM message m
+                         WHERE m.time_created >= ?1
+                         ORDER BY m.time_created ASC",
+                    )?;
+                    let iter = stmt.query_map([since], map_row)?;
+                    iter.collect::<rusqlite::Result<Vec<_>>>()?
+                }
+                None => {
+                    let mut stmt = conn.prepare(
+                        "SELECT m.data, m.session_id, m.time_created
+                         FROM message m
+                         ORDER BY m.time_created ASC",
+                    )?;
+                    let iter = stmt.query_map([], map_row)?;
+                    iter.collect::<rusqlite::Result<Vec<_>>>()?
+                }
+            }
+        };
 
-        let rows = stmt.query_map([], |row| {
-            Ok((
-                row.get::<_, String>(0)?,
-                row.get::<_, String>(1)?,
-                row.get::<_, i64>(2)?,
-            ))
-        })?;
-
-        for row in rows {
-            let (data_json, session_id, time_created) = row?;
-
+        for (data_json, session_id, time_created) in fetched {
             let msg: MessageData = match serde_json::from_str(&data_json) {
                 Ok(m) => m,
                 Err(_) => continue,
@@ -158,5 +194,101 @@ impl Collector for OpenCodeCollector {
         }
 
         Ok(records)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_db_path(label: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "llmusage-opencode-{label}-{}-{nanos}.sqlite",
+            std::process::id()
+        ))
+    }
+
+    fn build_fixture(path: &PathBuf) {
+        let conn = rusqlite::Connection::open(path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE message (
+                id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                time_created INTEGER NOT NULL,
+                data TEXT NOT NULL
+            );",
+        )
+        .unwrap();
+
+        let rows: Vec<(i64, &str)> = vec![
+            (
+                1_700_000_000_000,
+                r#"{"modelID":"m","providerID":"p","tokens":{"input":100,"output":10}}"#,
+            ),
+            (
+                1_700_000_005_000,
+                r#"{"modelID":"m","providerID":"p","tokens":{"input":200,"output":20}}"#,
+            ),
+            (
+                1_700_000_010_000,
+                r#"{"modelID":"m","providerID":"p","tokens":{"input":300,"output":30}}"#,
+            ),
+        ];
+        for (i, (ts, data)) in rows.iter().enumerate() {
+            conn.execute(
+                "INSERT INTO message (id, session_id, time_created, data) VALUES (?1, 's', ?2, ?3)",
+                rusqlite::params![format!("m{i}"), ts, data],
+            )
+            .unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn watermark_skips_older_messages() {
+        let path = temp_db_path("watermark");
+        build_fixture(&path);
+
+        let c = OpenCodeCollector::new()
+            .with_db_path(path.clone())
+            .with_watermark(Some(1_700_000_005_000));
+        let records = c.collect().await.unwrap();
+
+        assert_eq!(
+            records.len(),
+            2,
+            "watermark should include boundary + newer"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn no_watermark_reads_everything() {
+        let path = temp_db_path("full");
+        build_fixture(&path);
+
+        let c = OpenCodeCollector::new().with_db_path(path.clone());
+        let records = c.collect().await.unwrap();
+
+        assert_eq!(records.len(), 3);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn watermark_in_future_returns_empty() {
+        let path = temp_db_path("future");
+        build_fixture(&path);
+
+        let c = OpenCodeCollector::new()
+            .with_db_path(path.clone())
+            .with_watermark(Some(9_999_999_999_999));
+        let records = c.collect().await.unwrap();
+
+        assert!(records.is_empty());
+        let _ = std::fs::remove_file(path);
     }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -25,6 +25,10 @@ impl Database {
         queries::insert_record(&self.conn, record)
     }
 
+    pub fn max_recorded_at_millis(&self, provider: &str) -> Result<Option<i64>> {
+        queries::max_recorded_at_millis(&self.conn, provider)
+    }
+
     pub fn query_summary(
         &self,
         days: u32,

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use rusqlite::{params, Connection};
+use rusqlite::{params, Connection, OptionalExtension};
 
 use std::collections::BTreeMap;
 
@@ -26,6 +26,42 @@ pub fn insert_record(conn: &Connection, record: &UsageRecord) -> Result<()> {
         ],
     )?;
     Ok(())
+}
+
+/// Return the most recent `recorded_at` (as epoch milliseconds) for rows
+/// written by `provider`. Used as a watermark so local collectors can skip
+/// already-ingested history on every sync (issue #39).
+pub fn max_recorded_at_millis(conn: &Connection, provider: &str) -> Result<Option<i64>> {
+    let value: Option<String> = conn
+        .query_row(
+            "SELECT MAX(recorded_at) FROM usage_records WHERE provider = ?1",
+            params![provider],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .optional()?
+        .flatten();
+
+    let Some(s) = value else {
+        return Ok(None);
+    };
+
+    // recorded_at is written as either "%Y-%m-%dT%H:%M:%S" (local collectors)
+    // or as an RFC3339 / date-only string (API collectors). Try both.
+    if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(&s, "%Y-%m-%dT%H:%M:%S") {
+        return Ok(Some(dt.and_utc().timestamp_millis()));
+    }
+    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(&s) {
+        return Ok(Some(dt.timestamp_millis()));
+    }
+    if let Ok(date) = chrono::NaiveDate::parse_from_str(&s, "%Y-%m-%d") {
+        return Ok(Some(
+            date.and_hms_opt(0, 0, 0)
+                .unwrap()
+                .and_utc()
+                .timestamp_millis(),
+        ));
+    }
+    Ok(None)
 }
 
 pub fn query_summary(

--- a/src/main.rs
+++ b/src/main.rs
@@ -316,7 +316,7 @@ async fn cmd_sync(
         }
     }
 
-    let providers = collectors::get_collectors(cfg, provider_filter)?;
+    let providers = collectors::get_collectors(cfg, provider_filter, Some(db))?;
 
     if providers.is_empty() {
         if let Some(filter) = provider_filter {


### PR DESCRIPTION
## Summary

- **#39 (OpenCode full-table scan)**: OpenCodeCollector now supports an epoch-ms watermark derived from the max `recorded_at` stored for `provider = 'opencode'` in the llmusage DB. Sync SQL filters with `WHERE m.time_created >= ?`, so the cost of re-sync is bounded by new messages rather than total history.
- **#27 (Ollama 0-token heartbeat rows)**: already fixed in-tree — `OllamaCollector::collect` returns an empty vec and migration v2→v3 purges historical 0-token Ollama rows. This PR closes the issue.
- **#47 (Ollama collector always-on)**: already fixed in-tree — collector only runs when `cfg.ollama_enabled`. This PR closes the issue.

Watermark boundary is inclusive (`>=`) so any messages that landed within the same wall-second as the last ingested one are still re-seen and deduped by the existing unique index — avoids missing rows due to `recorded_at` being written at second precision.

## Test plan
- [x] `cargo test` (61 tests, all passing; 3 new opencode tests)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] Local smoke: run `llmusage sync --provider opencode` twice; second run should report 0 new records without re-reading history.

Closes #39
Closes #27
Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)