### PR TITLE
feat: address 5 open issues (#38, #43, #44, #50, #52)

### DIFF
--- a/src/collectors/anthropic.rs
+++ b/src/collectors/anthropic.rs
@@ -92,14 +92,13 @@ impl Collector for AnthropicCollector {
                 query.push(("page", p.clone()));
             }
 
-            let resp = self
+            let request = self
                 .client
                 .get("https://api.anthropic.com/v1/organizations/usage_report/messages")
                 .header("x-api-key", &self.api_key)
                 .header("anthropic-version", "2024-10-22")
-                .query(&query)
-                .send()
-                .await?;
+                .query(&query);
+            let resp = super::http::send_with_retry(request).await?;
 
             if !resp.status().is_success() {
                 let status = resp.status();

--- a/src/collectors/claude_code.rs
+++ b/src/collectors/claude_code.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use chrono::Utc;
 use serde::Deserialize;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use super::Collector;
 use crate::costs;
@@ -62,6 +62,82 @@ struct UsageData {
     cache_read_input_tokens: i64,
 }
 
+fn parse_jsonl_file(path: &Path, collected_at: &str) -> Vec<UsageRecord> {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+
+    let mut records = Vec::new();
+    for line in content.lines() {
+        if line.trim().is_empty() || !line.contains("\"usage\"") {
+            continue;
+        }
+
+        let Ok(entry) = serde_json::from_str::<LogEntry>(line) else {
+            continue;
+        };
+
+        if entry.r#type.as_deref() != Some("assistant") {
+            continue;
+        }
+
+        let Some(msg) = entry.message.as_ref() else {
+            continue;
+        };
+        let Some(usage) = msg.usage.as_ref() else {
+            continue;
+        };
+        if usage.input_tokens == 0 && usage.output_tokens == 0 {
+            continue;
+        }
+
+        let model = msg
+            .model
+            .clone()
+            .unwrap_or_else(|| "claude-unknown".to_string());
+
+        let cost = costs::calculate_cost(
+            &model,
+            "anthropic",
+            usage.input_tokens,
+            usage.output_tokens,
+            usage.cache_read_input_tokens,
+            usage.cache_creation_input_tokens,
+        );
+
+        records.push(UsageRecord {
+            id: None,
+            provider: "claude_code".to_string(),
+            model,
+            input_tokens: usage.input_tokens,
+            output_tokens: usage.output_tokens,
+            cache_read_tokens: usage.cache_read_input_tokens,
+            cache_write_tokens: usage.cache_creation_input_tokens,
+            cost_usd: cost,
+            session_id: entry.session_id.clone(),
+            recorded_at: entry
+                .timestamp
+                .clone()
+                .unwrap_or_else(|| Utc::now().format("%Y-%m-%dT%H:%M:%S").to_string()),
+            collected_at: collected_at.to_string(),
+            metadata: None,
+        });
+    }
+    records
+}
+
+fn collect_jsonl_in_dir(dir: &Path, collected_at: &str, records: &mut Vec<UsageRecord>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().is_some_and(|e| e == "jsonl") {
+            records.extend(parse_jsonl_file(&path, collected_at));
+        }
+    }
+}
+
 #[async_trait]
 impl Collector for ClaudeCodeCollector {
     fn name(&self) -> &str {
@@ -77,152 +153,70 @@ impl Collector for ClaudeCodeCollector {
         let collected_at = Utc::now().to_rfc3339();
         let mut records = Vec::new();
 
-        // Walk project directories for JSONL session logs
         for project_entry in std::fs::read_dir(&projects_dir)? {
             let project_entry = project_entry?;
             if !project_entry.file_type()?.is_dir() {
                 continue;
             }
-
-            // JSONL files are directly in the project directory
             let project_path = project_entry.path();
-            for file_entry in std::fs::read_dir(&project_path)? {
-                let file_entry = file_entry?;
-                let path = file_entry.path();
 
-                if path.extension().is_none_or(|e| e != "jsonl") {
-                    continue;
-                }
+            collect_jsonl_in_dir(&project_path, &collected_at, &mut records);
 
-                if let Ok(content) = std::fs::read_to_string(&path) {
-                    for line in content.lines() {
-                        if line.trim().is_empty() {
-                            continue;
-                        }
-
-                        // Quick filter: only parse lines that look like assistant messages with usage
-                        if !line.contains("\"usage\"") {
-                            continue;
-                        }
-
-                        if let Ok(entry) = serde_json::from_str::<LogEntry>(line) {
-                            // Only process assistant messages with usage data
-                            if entry.r#type.as_deref() != Some("assistant") {
-                                continue;
-                            }
-
-                            if let Some(ref msg) = entry.message {
-                                if let Some(ref usage) = msg.usage {
-                                    if usage.input_tokens == 0 && usage.output_tokens == 0 {
-                                        continue;
-                                    }
-
-                                    let model = msg
-                                        .model
-                                        .clone()
-                                        .unwrap_or_else(|| "claude-unknown".to_string());
-
-                                    let cost = costs::calculate_cost(
-                                        &model,
-                                        "anthropic",
-                                        usage.input_tokens,
-                                        usage.output_tokens,
-                                        usage.cache_read_input_tokens,
-                                        usage.cache_creation_input_tokens,
-                                    );
-
-                                    records.push(UsageRecord {
-                                        id: None,
-                                        provider: "claude_code".to_string(),
-                                        model,
-                                        input_tokens: usage.input_tokens,
-                                        output_tokens: usage.output_tokens,
-                                        cache_read_tokens: usage.cache_read_input_tokens,
-                                        cache_write_tokens: usage.cache_creation_input_tokens,
-                                        cost_usd: cost,
-                                        session_id: entry.session_id.clone(),
-                                        recorded_at: entry.timestamp.clone().unwrap_or_else(|| {
-                                            Utc::now().format("%Y-%m-%dT%H:%M:%S").to_string()
-                                        }),
-                                        collected_at: collected_at.clone(),
-                                        metadata: None,
-                                    });
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Also check subagents/ subdirectories
             let subagents_dir = project_path.join("subagents");
             if subagents_dir.exists() {
-                if let Ok(entries) = std::fs::read_dir(&subagents_dir) {
-                    for entry in entries.flatten() {
-                        let path = entry.path();
-                        if path.extension().is_some_and(|e| e == "jsonl") {
-                            if let Ok(content) = std::fs::read_to_string(&path) {
-                                for line in content.lines() {
-                                    if !line.contains("\"usage\"") {
-                                        continue;
-                                    }
-                                    if let Ok(entry) = serde_json::from_str::<LogEntry>(line) {
-                                        if entry.r#type.as_deref() != Some("assistant") {
-                                            continue;
-                                        }
-                                        if let Some(ref msg) = entry.message {
-                                            if let Some(ref usage) = msg.usage {
-                                                if usage.input_tokens == 0
-                                                    && usage.output_tokens == 0
-                                                {
-                                                    continue;
-                                                }
-                                                let model =
-                                                    msg.model.clone().unwrap_or_else(|| {
-                                                        "claude-unknown".to_string()
-                                                    });
-                                                let cost = costs::calculate_cost(
-                                                    &model,
-                                                    "anthropic",
-                                                    usage.input_tokens,
-                                                    usage.output_tokens,
-                                                    usage.cache_read_input_tokens,
-                                                    usage.cache_creation_input_tokens,
-                                                );
-                                                records.push(UsageRecord {
-                                                    id: None,
-                                                    provider: "claude_code".to_string(),
-                                                    model,
-                                                    input_tokens: usage.input_tokens,
-                                                    output_tokens: usage.output_tokens,
-                                                    cache_read_tokens: usage
-                                                        .cache_read_input_tokens,
-                                                    cache_write_tokens: usage
-                                                        .cache_creation_input_tokens,
-                                                    cost_usd: cost,
-                                                    session_id: entry.session_id.clone(),
-                                                    recorded_at: entry
-                                                        .timestamp
-                                                        .clone()
-                                                        .unwrap_or_else(|| {
-                                                            Utc::now()
-                                                                .format("%Y-%m-%dT%H:%M:%S")
-                                                                .to_string()
-                                                        }),
-                                                    collected_at: collected_at.clone(),
-                                                    metadata: None,
-                                                });
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+                collect_jsonl_in_dir(&subagents_dir, &collected_at, &mut records);
             }
         }
 
         Ok(records)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn tempfile_path(tag: &str) -> PathBuf {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "llmusage-{tag}-{}-{nanos}.jsonl",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn parse_jsonl_file_extracts_assistant_usage_and_skips_others() {
+        let path = tempfile_path("claude-code-jsonl");
+        let file = std::fs::File::create(&path).unwrap();
+        let mut w = std::io::BufWriter::new(file);
+        writeln!(w, r#"{{"type":"user","message":{{"content":"hi"}}}}"#).unwrap();
+        writeln!(
+            w,
+            r#"{{"type":"assistant","sessionId":"s1","timestamp":"2026-04-01T00:00:00Z","message":{{"model":"claude-sonnet-4","usage":{{"input_tokens":0,"output_tokens":0}}}}}}"#
+        )
+        .unwrap();
+        writeln!(
+            w,
+            r#"{{"type":"assistant","sessionId":"s1","timestamp":"2026-04-01T00:00:01Z","message":{{"model":"claude-sonnet-4","usage":{{"input_tokens":10,"output_tokens":5,"cache_read_input_tokens":2,"cache_creation_input_tokens":3}}}}}}"#
+        )
+        .unwrap();
+        drop(w);
+
+        let recs = parse_jsonl_file(&path, "2026-04-01T00:00:02Z");
+        let _ = std::fs::remove_file(&path);
+
+        assert_eq!(recs.len(), 1);
+        let r = &recs[0];
+        assert_eq!(r.provider, "claude_code");
+        assert_eq!(r.input_tokens, 10);
+        assert_eq!(r.output_tokens, 5);
+        assert_eq!(r.cache_read_tokens, 2);
+        assert_eq!(r.cache_write_tokens, 3);
+        assert_eq!(r.session_id.as_deref(), Some("s1"));
     }
 }

--- a/src/collectors/http.rs
+++ b/src/collectors/http.rs
@@ -1,0 +1,82 @@
+//! Shared HTTP helpers for API-based collectors.
+//!
+//! Transient network failures and 429/5xx responses are retried with
+//! exponential backoff. Auth/client errors (401, 403, 404, other 4xx) are
+//! returned immediately — retrying cannot recover them and a second request
+//! only delays the user's error message.
+
+use std::time::Duration;
+
+use reqwest::{RequestBuilder, Response, StatusCode};
+
+/// Max attempts (including the first). Three attempts = up to two retries.
+const MAX_ATTEMPTS: u32 = 3;
+/// Base backoff; actual delay = BACKOFF_BASE * 2^(attempt-1) → 1s, 2s, 4s.
+const BACKOFF_BASE: Duration = Duration::from_secs(1);
+
+fn is_retryable_status(status: StatusCode) -> bool {
+    status == StatusCode::TOO_MANY_REQUESTS || matches!(status.as_u16(), 500 | 502 | 503 | 504)
+}
+
+/// Clone a request and send it with retry-on-transient-failure semantics.
+///
+/// The request must be clone-able, which in `reqwest` means the body (if any)
+/// must itself be clone-able. Our usage — GET with query params, no body —
+/// always is.
+pub async fn send_with_retry(request: RequestBuilder) -> reqwest::Result<Response> {
+    let mut attempt = 0u32;
+    loop {
+        attempt += 1;
+        // try_clone returns None if the body is a stream; all of our API
+        // requests are GETs with no body, so this is safe.
+        let this_attempt = match request.try_clone() {
+            Some(rb) => rb,
+            None => return request.send().await,
+        };
+        match this_attempt.send().await {
+            Ok(resp) => {
+                if attempt < MAX_ATTEMPTS && is_retryable_status(resp.status()) {
+                    sleep_backoff(attempt).await;
+                    continue;
+                }
+                return Ok(resp);
+            }
+            Err(err) => {
+                if attempt < MAX_ATTEMPTS && is_transient_error(&err) {
+                    sleep_backoff(attempt).await;
+                    continue;
+                }
+                return Err(err);
+            }
+        }
+    }
+}
+
+fn is_transient_error(err: &reqwest::Error) -> bool {
+    err.is_timeout() || err.is_connect() || err.is_request()
+}
+
+async fn sleep_backoff(attempt: u32) {
+    let factor = 1u32 << (attempt - 1).min(6);
+    tokio::time::sleep(BACKOFF_BASE * factor).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retries_429_and_5xx_but_not_4xx() {
+        assert!(is_retryable_status(StatusCode::TOO_MANY_REQUESTS));
+        assert!(is_retryable_status(StatusCode::INTERNAL_SERVER_ERROR));
+        assert!(is_retryable_status(StatusCode::BAD_GATEWAY));
+        assert!(is_retryable_status(StatusCode::SERVICE_UNAVAILABLE));
+        assert!(is_retryable_status(StatusCode::GATEWAY_TIMEOUT));
+
+        assert!(!is_retryable_status(StatusCode::UNAUTHORIZED));
+        assert!(!is_retryable_status(StatusCode::FORBIDDEN));
+        assert!(!is_retryable_status(StatusCode::NOT_FOUND));
+        assert!(!is_retryable_status(StatusCode::BAD_REQUEST));
+        assert!(!is_retryable_status(StatusCode::OK));
+    }
+}

--- a/src/collectors/mod.rs
+++ b/src/collectors/mod.rs
@@ -5,6 +5,7 @@ pub mod cursor;
 pub mod deepseek;
 pub mod gemini;
 pub mod gemini_cli;
+pub mod http;
 pub mod ollama;
 pub mod openai;
 pub mod opencode;
@@ -400,4 +401,82 @@ fn vscode_state_db_path() -> PathBuf {
         .join("User")
         .join("globalStorage")
         .join("state.vscdb")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_config() -> Config {
+        Config {
+            db_path: "db.sqlite".into(),
+            anthropic_api_key: None,
+            openai_api_key: None,
+            gemini_api_key: None,
+            openrouter_api_key: None,
+            deepseek_api_key: None,
+            ollama_host: None,
+            ollama_enabled: false,
+            claude_code_enabled: false,
+            config_path: PathBuf::from("config.toml"),
+        }
+    }
+
+    #[test]
+    fn explain_provider_filter_mentions_named_provider() {
+        let cfg = empty_config();
+        for name in [
+            "anthropic",
+            "openai",
+            "gemini",
+            "openrouter",
+            "deepseek",
+            "ollama",
+            "claude_code",
+            "codex",
+            "opencode",
+            "gemini_cli",
+            "cursor",
+            "windsurf",
+            "vscode",
+        ] {
+            let msg = explain_provider_filter(&cfg, name);
+            assert!(
+                msg.contains(name) || msg.contains("strict mode"),
+                "message for {name} should reference it: {msg:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn explain_provider_filter_handles_aliases() {
+        let cfg = empty_config();
+        let msg = explain_provider_filter(&cfg, "antigravity");
+        assert!(
+            msg.to_lowercase().contains("gemini") || msg.contains("Antigravity"),
+            "antigravity alias should resolve to gemini_cli guidance, got: {msg:?}"
+        );
+    }
+
+    #[test]
+    fn explain_provider_filter_reports_unknown_names() {
+        let cfg = empty_config();
+        let msg = explain_provider_filter(&cfg, "antropic");
+        assert!(msg.contains("Unknown provider"), "got: {msg:?}");
+        assert!(msg.contains("antropic"), "got: {msg:?}");
+    }
+
+    #[test]
+    fn explain_provider_filter_distinguishes_configured_vs_missing() {
+        let mut cfg = empty_config();
+        let missing = explain_provider_filter(&cfg, "openai");
+        assert!(
+            missing.contains("requires `openai_api_key`"),
+            "got: {missing:?}"
+        );
+
+        cfg.openai_api_key = Some("sk-test".into());
+        let configured = explain_provider_filter(&cfg, "openai");
+        assert!(configured.contains("configured"), "got: {configured:?}");
+    }
 }

--- a/src/collectors/openai.rs
+++ b/src/collectors/openai.rs
@@ -78,13 +78,12 @@ impl Collector for OpenAICollector {
                 query.push(("page", p.clone()));
             }
 
-            let resp = self
+            let request = self
                 .client
                 .get("https://api.openai.com/v1/organization/usage/completions")
                 .bearer_auth(&self.api_key)
-                .query(&query)
-                .send()
-                .await?;
+                .query(&query);
+            let resp = super::http::send_with_retry(request).await?;
 
             if !resp.status().is_success() {
                 let status = resp.status();

--- a/src/config.rs
+++ b/src/config.rs
@@ -352,6 +352,51 @@ mod tests {
         let _ = std::fs::remove_file(path);
     }
 
+    fn cfg_with_path(path: PathBuf) -> Config {
+        Config {
+            db_path: "db.sqlite".to_string(),
+            anthropic_api_key: None,
+            openai_api_key: None,
+            gemini_api_key: None,
+            openrouter_api_key: None,
+            deepseek_api_key: None,
+            ollama_host: None,
+            ollama_enabled: false,
+            claude_code_enabled: true,
+            config_path: path,
+        }
+    }
+
+    #[test]
+    fn set_config_value_rejects_unknown_key() {
+        let path = temp_path("set-unknown");
+        let cfg = cfg_with_path(path.clone());
+        let err = set_config_value(&cfg, "does_not_exist", "x").unwrap_err();
+        assert!(err.to_string().contains("Unknown config key"));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn set_config_value_reports_parse_errors_for_typed_keys() {
+        let path = temp_path("set-parse");
+        let cfg = cfg_with_path(path.clone());
+        let err = set_config_value(&cfg, "ollama_enabled", "not-a-bool").unwrap_err();
+        // anyhow wraps the ParseBoolError.
+        assert!(err.to_string().to_lowercase().contains("bool") || !err.to_string().is_empty());
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn set_config_value_persists_string_keys() {
+        let path = temp_path("set-string");
+        let cfg = cfg_with_path(path.clone());
+        set_config_value(&cfg, "anthropic_api_key", "sk-test").unwrap();
+
+        let reloaded: Config = toml::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(reloaded.anthropic_api_key.as_deref(), Some("sk-test"));
+        let _ = std::fs::remove_file(path);
+    }
+
     #[test]
     #[cfg(unix)]
     fn load_config_tightens_existing_file_permissions() {

--- a/src/costs.rs
+++ b/src/costs.rs
@@ -519,4 +519,21 @@ mod fallback_tests {
     fn deepseek_normalizes_to_deepseek() {
         assert_eq!(normalize_provider("deepseek"), Some("deepseek"));
     }
+
+    #[test]
+    fn normalize_provider_covers_known_aliases() {
+        assert_eq!(normalize_provider("anthropic"), Some("anthropic"));
+        assert_eq!(normalize_provider("openai"), Some("openai"));
+        assert_eq!(normalize_provider("vertex_ai"), Some("gemini"));
+        assert_eq!(normalize_provider("vertex_ai_beta"), Some("gemini"));
+        assert_eq!(normalize_provider("ollama_chat"), Some("ollama"));
+        assert_eq!(normalize_provider("azure_ai"), Some("azure"));
+        assert_eq!(normalize_provider("cohere_chat"), Some("cohere"));
+    }
+
+    #[test]
+    fn normalize_provider_rejects_unknown() {
+        assert_eq!(normalize_provider("unknown-thing"), None);
+        assert_eq!(normalize_provider(""), None);
+    }
 }

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Result};
 use rusqlite::Connection;
 
-const LATEST_SCHEMA_VERSION: i64 = 3;
+const LATEST_SCHEMA_VERSION: i64 = 4;
 
 const CREATE_USAGE_RECORDS_TABLE_SQL: &str = "
     CREATE TABLE IF NOT EXISTS usage_records (
@@ -33,7 +33,8 @@ const CREATE_INDEXES_SQL: &str = "
         cache_read_tokens,
         cache_write_tokens,
         recorded_at,
-        COALESCE(session_id, '')
+        COALESCE(session_id, ''),
+        COALESCE(cost_usd, -1)
     );
 ";
 
@@ -98,6 +99,7 @@ fn migrate(conn: &Connection, from: i64, to: i64) -> Result<()> {
         match version {
             1 => migrate_v1_to_v2(&tx)?,
             2 => migrate_v2_to_v3(&tx)?,
+            3 => migrate_v3_to_v4(&tx)?,
             _ => bail!("No migration path from schema version {}", version),
         }
         version += 1;
@@ -125,6 +127,27 @@ fn migrate_v2_to_v3(conn: &Connection) -> Result<()> {
            AND cache_read_tokens = 0
            AND cache_write_tokens = 0",
         [],
+    )?;
+    Ok(())
+}
+
+// Rebuild idx_dedup with cost_usd as a trailing column so that two legitimately
+// distinct API calls with identical token counts but different costs are no
+// longer dropped by INSERT OR IGNORE (issue #50).
+fn migrate_v3_to_v4(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "DROP INDEX IF EXISTS idx_dedup;
+         CREATE UNIQUE INDEX idx_dedup ON usage_records(
+             provider,
+             model,
+             input_tokens,
+             output_tokens,
+             cache_read_tokens,
+             cache_write_tokens,
+             recorded_at,
+             COALESCE(session_id, ''),
+             COALESCE(cost_usd, -1)
+         );",
     )?;
     Ok(())
 }
@@ -284,6 +307,102 @@ mod tests {
         assert!(err.to_string().contains("usage_records"));
         assert_eq!(current_schema_version(&conn).unwrap(), 1);
         assert!(!index_exists(&conn, "idx_provider").unwrap());
+    }
+
+    #[test]
+    fn dedup_index_admits_records_differing_only_by_cost() {
+        let conn = Connection::open_in_memory().unwrap();
+        initialize(&conn).unwrap();
+
+        let insert = "INSERT OR IGNORE INTO usage_records (
+            provider, model, input_tokens, output_tokens,
+            cache_read_tokens, cache_write_tokens, cost_usd, session_id,
+            recorded_at, collected_at, metadata
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)";
+
+        let first = conn
+            .execute(
+                insert,
+                rusqlite::params![
+                    "anthropic",
+                    "claude-sonnet-4-6",
+                    100,
+                    50,
+                    0,
+                    0,
+                    0.10_f64,
+                    Option::<String>::None,
+                    "2026-04-18",
+                    "2026-04-18T12:00:00Z",
+                    Option::<String>::None,
+                ],
+            )
+            .unwrap();
+        assert_eq!(first, 1);
+
+        // Same token shape, different cost → should NOT be dropped.
+        let second = conn
+            .execute(
+                insert,
+                rusqlite::params![
+                    "anthropic",
+                    "claude-sonnet-4-6",
+                    100,
+                    50,
+                    0,
+                    0,
+                    0.20_f64,
+                    Option::<String>::None,
+                    "2026-04-18",
+                    "2026-04-18T12:00:00Z",
+                    Option::<String>::None,
+                ],
+            )
+            .unwrap();
+        assert_eq!(second, 1);
+
+        // Exact duplicate (same cost too) → dropped.
+        let third = conn
+            .execute(
+                insert,
+                rusqlite::params![
+                    "anthropic",
+                    "claude-sonnet-4-6",
+                    100,
+                    50,
+                    0,
+                    0,
+                    0.10_f64,
+                    Option::<String>::None,
+                    "2026-04-18",
+                    "2026-04-18T12:00:00Z",
+                    Option::<String>::None,
+                ],
+            )
+            .unwrap();
+        assert_eq!(third, 0);
+    }
+
+    #[test]
+    fn upgrades_v3_database_to_v4_with_cost_aware_dedup_index() {
+        let conn = Connection::open_in_memory().unwrap();
+        create_schema_v1(&conn).unwrap();
+        set_schema_version(&conn, 3).unwrap();
+
+        initialize(&conn).unwrap();
+
+        assert_eq!(current_schema_version(&conn).unwrap(), 4);
+        let sql: String = conn
+            .query_row(
+                "SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_dedup'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(
+            sql.contains("cost_usd"),
+            "idx_dedup should include cost_usd after migration, got: {sql}"
+        );
     }
 
     #[test]

--- a/src/display.rs
+++ b/src/display.rs
@@ -744,4 +744,41 @@ mod format_tests {
     fn i64_min_does_not_panic() {
         let _ = format_tokens_comma(i64::MIN);
     }
+
+    use super::{format_cost, shorten_model, strip_date_suffix};
+
+    #[test]
+    fn format_cost_picks_precision_by_magnitude() {
+        assert_eq!(format_cost(0.0), "$0.00");
+        assert_eq!(format_cost(0.0001), "$0.0001");
+        assert_eq!(format_cost(0.015), "$0.015");
+        assert_eq!(format_cost(1.2345), "$1.23");
+        assert_eq!(format_cost(123.456), "$123.46");
+    }
+
+    #[test]
+    fn shorten_model_strips_known_prefixes_and_dates() {
+        assert_eq!(shorten_model("claude-opus-4-6-20260205"), "opus-4-6");
+        assert_eq!(shorten_model("claude-sonnet-4-20250514"), "sonnet-4");
+        assert_eq!(shorten_model("claude-haiku-4-5-20251001"), "haiku-4-5");
+        assert_eq!(
+            shorten_model("antigravity-gemini-3-flash"),
+            "gemini-3-flash"
+        );
+        assert_eq!(
+            shorten_model("antigravity-claude-opus-4-5-thinking"),
+            "opus-4-5-thinking"
+        );
+        // Unrelated names should pass through unchanged.
+        assert_eq!(shorten_model("gpt-4o-mini"), "gpt-4o-mini");
+    }
+
+    #[test]
+    fn strip_date_suffix_removes_only_trailing_dash_date() {
+        assert_eq!(strip_date_suffix("sonnet-4-20250514"), "sonnet-4");
+        assert_eq!(strip_date_suffix("gpt-4o-mini"), "gpt-4o-mini");
+        assert_eq!(strip_date_suffix("short"), "short");
+        // Looks date-like but missing dash prefix.
+        assert_eq!(strip_date_suffix("v20250514"), "v20250514");
+    }
 }


### PR DESCRIPTION
## Summary

Bundle of small, low-risk fixes for 5 open issues.

- **#38** Claude Code collector — extract shared `parse_jsonl_file` helper so the main-session and `subagents/` scans no longer have copy-pasted parsing logic.
- **#43** HTTP retry — new `collectors::http::send_with_retry` wraps the Anthropic and OpenAI API calls with a 3-attempt, 1s/2s/4s exponential backoff. Retries on 429, 500-504, and connect/timeout/request errors. 4xx auth errors fail immediately.
- **#50** Dedup index — schema migration v3→v4 rebuilds `idx_dedup` with `cost_usd` as a trailing column. Two records with identical token counts but different costs are no longer silently dropped by `INSERT OR IGNORE`.
- **#52** Sync provider messaging — added regression tests for `explain_provider_filter` covering all known providers, aliases, configured-vs-missing distinction, and the unknown-name path. Clap `ValueEnum` already rejects unknown `--provider` values at parse time; tests lock in the downstream messaging.
- **#44** Test coverage — added unit tests for `display::format_cost`, `shorten_model`, `strip_date_suffix`, `costs::normalize_provider` aliases, and `config::set_config_value` happy + error paths.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 74 tests passing, including new ones:
  - `parse_jsonl_file_extracts_assistant_usage_and_skips_others`
  - `retries_429_and_5xx_but_not_4xx`
  - `dedup_index_admits_records_differing_only_by_cost`
  - `upgrades_v3_database_to_v4_with_cost_aware_dedup_index`
  - `explain_provider_filter_*` (4 tests)
  - `set_config_value_*` (3 tests)
  - `normalize_provider_*`, `format_cost_*`, `shorten_model_*`, `strip_date_suffix_*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)